### PR TITLE
ci: streamline release assets and add download guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,6 @@ jobs:
             dist/Codex-Tweaks-${{ env.RELEASE_TAG }}.dmg
             dist/Codex-Tweaks-${{ env.RELEASE_TAG }}-arm64.dmg
             dist/Codex-Tweaks-${{ env.RELEASE_TAG }}-x86_64.dmg
-            dist/SHA256SUMS
           if-no-files-found: error
           retention-days: 7
 
@@ -159,30 +158,21 @@ jobs:
           name: release-windows-${{ env.RELEASE_TAG }}
           path: release-assets/windows
 
-      - name: Check existing release
-        id: release
+      - name: Generate bilingual download guide
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          error_file="$RUNNER_TEMP/release-check-error"
-          if gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG" > /dev/null 2> "$error_file"; then
-            echo "exists=true" >> "$GITHUB_OUTPUT"
-          elif grep -q "HTTP 404" "$error_file"; then
-            echo "exists=false" >> "$GITHUB_OUTPUT"
-          else
-            cat "$error_file" >&2
-            exit 1
-          fi
+          RELEASE_ASSET_ROOT: release-assets
+          RELEASE_BODY_PATH: release-assets/release-body.md
+        run: ./scripts/generate-release-body.sh
 
       - name: Publish release
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: ${{ env.RELEASE_TAG }}
+          body_path: release-assets/release-body.md
           files: |
             release-assets/macos/*
             release-assets/windows/*
           fail_on_unmatched_files: true
           prerelease: ${{ contains(env.RELEASE_TAG, '-') }}
-          generate_release_notes: ${{ steps.release.outputs.exists != 'true' }}
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -101,8 +101,13 @@ Codex Tweaks 每 2 秒重新发现页面与包状态。注入使用产物指纹�
 
 从 [GitHub Releases](https://github.com/cr-zhichen/codex-tweaks/releases) 下载对应平台与架构的文件：
 
-- macOS：打开 universal、arm64 或 x86_64 DMG，将 Codex Tweaks 拖移到“应用程序”。当前使用 ad-hoc 签名且未经 Apple 公证；如果系统阻止首次打开，请在“系统设置 → 隐私与安全性”中确认。
-- Windows：运行名称中包含 `win-x64` 或 `win-arm64` 的 `Setup.exe`。Velopack 默认安装到当前用户目录，不弹出管理员权限；可从“设置 → 应用 → 已安装的应用”卸载。测试版允许未签名发布，因此 Windows SmartScreen 可能要求用户确认运行。
+- macOS universal：下载不带架构后缀的 DMG，同时支持 Apple Silicon 与 Intel Mac，默认推荐。
+- macOS Apple Silicon：下载名称以 `-arm64.dmg` 结尾的较小安装包。
+- macOS Intel：下载名称以 `-x86_64.dmg` 结尾的较小安装包。
+- Windows x64：下载名称以 `-x86_64.exe` 结尾的安装器，适用于 Intel 与 AMD 64 位电脑。
+- Windows ARM64：下载名称以 `-arm64.exe` 结尾的安装器，适用于 Snapdragon 等 ARM64 电脑。
+
+macOS 打开 DMG 后将 Codex Tweaks 拖移到“应用程序”。当前使用 ad-hoc 签名且未经 Apple 公证；如果系统阻止首次打开，请在“系统设置 → 隐私与安全性”中确认。Windows 安装器默认安装到当前用户目录，不弹出管理员权限；可从“设置 → 应用 → 已安装的应用”卸载。测试版允许未签名发布，因此 Windows SmartScreen 可能要求用户确认运行。Release 中的 `.nupkg` 和 `releases.*.json` 仅供应用内自动更新使用，普通用户无需手动下载。
 
 Windows 应用会根据用户选择的正式版或测试版通道读取同一 GitHub Release 中的 Velopack feed，下载后整体替换 WinUI 前端、Go sidecar 和全部随包资源并重启。打包脚本预留 `VPK_AZURE_TRUSTED_SIGN_FILE` 与 `VPK_SIGN_TEMPLATE`：接入 Azure Trusted Signing 或其他托管签名命令后，无需修改应用或更新协议。
 
@@ -124,7 +129,7 @@ Windows 开发需要 Go 与 .NET 8 SDK。以下命令生成 x64、ARM64 两套 s
 ./scripts/verify-windows.ps1 -Version 3.0.0-beta.1 -Channel beta -RequirePackages
 ```
 
-构建输出位于 `artifacts/windows/win-x64`、`artifacts/windows/win-arm64`，待发布文件统一暂存到 `artifacts/windows/release`。
+构建输出位于 `artifacts/windows/win-x64`、`artifacts/windows/win-arm64`。每个架构只把安装器、完整更新包和当前通道 feed 三个必需文件暂存到 `artifacts/windows/release`。
 
 ## 功能包格式
 
@@ -312,7 +317,7 @@ mise run clean           # 清理 build/ 与 dist/
 
 CI 在 `main`、Pull Request 和手动触发时并行验证两套原生应用：macOS 运行 Go race tests、Swift tests 和 Release App 构建；Windows 在 Windows runner 上运行 Go 原生测试、x64/ARM64 self-contained WinUI 发布、Velopack 打包、PE 架构校验和本机架构 sidecar RPC 冒烟测试。
 
-推送 `v*` 标签后，Release 工作流会并行构建三套 macOS DMG 与两套 Windows Velopack 发行包，全部通过后才创建或更新同一个 GitHub Release。带预发布后缀的标签进入 `beta` feed，普通 SemVer 标签进入 `stable` feed。
+推送 `v*` 标签后，Release 工作流会并行构建 universal、arm64、x86_64 三套 macOS DMG 与两套 Windows Velopack 发行包，全部通过后才创建或更新同一个 GitHub Release，并在自动生成的发行说明前加入中英文系统下载链接。带预发布后缀的标签进入 `beta` feed，普通 SemVer 标签进入 `stable` feed。
 
 ## 验证范围
 

--- a/scripts/generate-release-body.sh
+++ b/scripts/generate-release-body.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_TAG="${RELEASE_TAG:-${1:-}}"
+RELEASE_BODY_PATH="${RELEASE_BODY_PATH:-${2:-release-body.md}}"
+GITHUB_SERVER_URL="${GITHUB_SERVER_URL:-https://github.com}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-cr-zhichen/codex-tweaks}"
+RELEASE_ASSET_ROOT="${RELEASE_ASSET_ROOT:-}"
+
+if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$ ]]; then
+  echo "RELEASE_TAG 必须是 v1.2.3 或 v1.2.3-beta.1 形式" >&2
+  exit 1
+fi
+
+release_version="${RELEASE_TAG#v}"
+download_base="${GITHUB_SERVER_URL%/}/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+macos_universal_asset="Codex-Tweaks-${RELEASE_TAG}.dmg"
+macos_arm64_asset="Codex-Tweaks-${RELEASE_TAG}-arm64.dmg"
+macos_x86_64_asset="Codex-Tweaks-${RELEASE_TAG}-x86_64.dmg"
+windows_x64_asset="Codex-Tweaks-v${release_version}-windows-Setup-x86_64.exe"
+windows_arm64_asset="Codex-Tweaks-v${release_version}-windows-Setup-arm64.exe"
+
+if [[ -n "$RELEASE_ASSET_ROOT" ]]; then
+  required_assets=(
+    "${RELEASE_ASSET_ROOT}/macos/${macos_universal_asset}"
+    "${RELEASE_ASSET_ROOT}/macos/${macos_arm64_asset}"
+    "${RELEASE_ASSET_ROOT}/macos/${macos_x86_64_asset}"
+    "${RELEASE_ASSET_ROOT}/windows/${windows_x64_asset}"
+    "${RELEASE_ASSET_ROOT}/windows/${windows_arm64_asset}"
+  )
+  for asset in "${required_assets[@]}"; do
+    if [[ ! -f "$asset" ]]; then
+      echo "发布说明引用的文件不存在：$asset" >&2
+      exit 1
+    fi
+  done
+fi
+
+mkdir -p "$(dirname -- "$RELEASE_BODY_PATH")"
+cat > "$RELEASE_BODY_PATH" <<EOF
+## 下载 / Downloads
+
+| 系统 / System | 下载 / Download | 适用于 / For |
+| --- | --- | --- |
+| macOS 13+ universal（推荐 / Recommended） | [${macos_universal_asset}](${download_base}/${macos_universal_asset}) | Apple Silicon（M 系列）与 Intel Mac / Apple Silicon and Intel Macs |
+| macOS 13+ Apple Silicon | [${macos_arm64_asset}](${download_base}/${macos_arm64_asset}) | Apple Silicon（M 系列），文件更小 / Apple Silicon Macs, smaller download |
+| macOS 13+ Intel | [${macos_x86_64_asset}](${download_base}/${macos_x86_64_asset}) | Intel Mac，文件更小 / Intel Macs, smaller download |
+| Windows x64 | [${windows_x64_asset}](${download_base}/${windows_x64_asset}) | Intel、AMD 64 位 Windows 电脑 / 64-bit Intel and AMD Windows PCs |
+| Windows ARM64 | [${windows_arm64_asset}](${download_base}/${windows_arm64_asset}) | Snapdragon 等 ARM64 Windows 电脑 / ARM64 Windows PCs such as Snapdragon devices |
+
+### 安装提示 / Installation notes
+
+- 中文：普通用户只需下载上表中与自己系统对应的文件。macOS 打开 DMG 后拖入 Applications（应用程序）；Windows 运行对应的 EXE 安装器。
+- English: Most users only need the matching file in the table. On macOS, open the DMG and drag the app to Applications. On Windows, run the matching EXE installer.
+- 中文：Release 中的 <code>.nupkg</code> 和 <code>releases.*.json</code> 供 Windows 应用内自动更新使用，请勿手动下载。
+- English: The <code>.nupkg</code> and <code>releases.*.json</code> assets are used by the Windows in-app updater and should not be downloaded manually.
+
+EOF
+
+echo "已生成双语 Release 下载说明：${RELEASE_BODY_PATH}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -89,13 +89,4 @@ create_dmg "$PRODUCT_NAME" "Codex-Tweaks-${RELEASE_TAG}.dmg"
 create_dmg "${PRODUCT_NAME}-arm64" "Codex-Tweaks-${RELEASE_TAG}-arm64.dmg"
 create_dmg "${PRODUCT_NAME}-x86_64" "Codex-Tweaks-${RELEASE_TAG}-x86_64.dmg"
 
-(
-  cd "$DIST_DIR"
-  shasum -a 256 \
-    "Codex-Tweaks-${RELEASE_TAG}.dmg" \
-    "Codex-Tweaks-${RELEASE_TAG}-arm64.dmg" \
-    "Codex-Tweaks-${RELEASE_TAG}-x86_64.dmg" \
-    > SHA256SUMS
-)
-
 echo "Release ${RELEASE_TAG} 构建完成（版本 ${MARKETING_VERSION}，构建号 ${BUILD_NUMBER}）"

--- a/scripts/package-windows.ps1
+++ b/scripts/package-windows.ps1
@@ -25,13 +25,18 @@ try {
     & dotnet tool restore
     if ($LASTEXITCODE -ne 0) { throw 'Unable to restore the pinned Velopack CLI.' }
 
+    $releaseAssets = @()
     foreach ($rid in $RuntimeIdentifiers) {
         $architecture = if ($rid -eq 'win-arm64') { 'arm64' } else { 'x64' }
+        $downloadArchitecture = if ($rid -eq 'win-arm64') { 'arm64' } else { 'x86_64' }
         $packId = "com.crzhichen.CodexTweaks.$architecture"
         $publish = Join-Path $artifactRoot "$rid/publish"
         $releases = Join-Path $artifactRoot "$rid/releases"
         if (-not (Test-Path (Join-Path $publish 'CodexTweaks.Windows.exe'))) {
             throw "Missing $rid publish output. Run scripts/build-windows.ps1 first."
+        }
+        if (Test-Path $releases) {
+            Remove-Item -Recurse -Force $releases
         }
         New-Item -ItemType Directory -Force -Path $releases | Out-Null
 
@@ -61,11 +66,21 @@ try {
         if ($LASTEXITCODE -ne 0) { throw "Velopack packaging failed: $rid" }
         $channelName = "win-$architecture-$Channel"
         $generatedSetup = Join-Path $releases "$packId-$channelName-Setup.exe"
-        $versionedSetup = Join-Path $releases "$packId-$Version-$channelName-Setup.exe"
+        $versionedSetup = Join-Path $releases "Codex-Tweaks-v${Version}-windows-Setup-${downloadArchitecture}.exe"
         if (-not (Test-Path $generatedSetup)) {
             throw "Velopack did not create the expected installer: $generatedSetup"
         }
         Move-Item -Force $generatedSetup $versionedSetup
+
+        $fullPackages = @(Get-ChildItem $releases -Filter '*-full.nupkg' -File)
+        if ($fullPackages.Count -ne 1) {
+            throw "Expected exactly one Velopack full package for $rid, found $($fullPackages.Count)."
+        }
+        $feed = Join-Path $releases "releases.$channelName.json"
+        if (-not (Test-Path $feed -PathType Leaf)) {
+            throw "Missing Velopack channel feed: $feed"
+        }
+        $releaseAssets += @($versionedSetup, $fullPackages[0].FullName, $feed)
         Write-Host "Packaged $rid / $Channel -> $releases"
     }
 
@@ -73,23 +88,14 @@ try {
         Remove-Item -Recurse -Force $stagedRelease
     }
     New-Item -ItemType Directory -Force -Path $stagedRelease | Out-Null
-    foreach ($rid in $RuntimeIdentifiers) {
-        $releases = Join-Path $artifactRoot "$rid/releases"
-        foreach ($file in Get-ChildItem $releases -File) {
-            $destination = Join-Path $stagedRelease $file.Name
-            if (Test-Path $destination) {
-                throw "Duplicate staged release asset: $($file.Name)"
-            }
-            Copy-Item $file.FullName $destination
+    foreach ($assetPath in $releaseAssets) {
+        $fileName = Split-Path -Leaf $assetPath
+        $destination = Join-Path $stagedRelease $fileName
+        if (Test-Path $destination) {
+            throw "Duplicate staged release asset: $fileName"
         }
+        Copy-Item $assetPath $destination
     }
-    $checksums = Get-ChildItem $stagedRelease -File | Sort-Object Name | ForEach-Object {
-        $hash = (Get-FileHash $_.FullName -Algorithm SHA256).Hash.ToLowerInvariant()
-        "$hash  $($_.Name)"
-    }
-    $checksumPath = Join-Path $stagedRelease 'SHA256SUMS-Windows'
-    $utf8NoBOM = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllLines($checksumPath, [string[]]$checksums, $utf8NoBOM)
     Write-Host "Staged Windows release assets -> $stagedRelease"
 }
 finally {

--- a/scripts/verify-release.sh
+++ b/scripts/verify-release.sh
@@ -103,9 +103,4 @@ for dmg in \
   hdiutil verify "$dmg"
 done
 
-(
-  cd "$DIST_DIR"
-  shasum -a 256 -c SHA256SUMS
-)
-
 echo "Release ${RELEASE_TAG} 的全部产物校验通过"

--- a/scripts/verify-windows.ps1
+++ b/scripts/verify-windows.ps1
@@ -141,8 +141,10 @@ function Invoke-BackendSmoke([string]$Backend, [string]$Publish, [string]$Expect
     }
 }
 
+$expectedReleaseAssets = @()
 foreach ($rid in $RuntimeIdentifiers) {
     $architecture = if ($rid -eq 'win-arm64') { 'arm64' } else { 'x64' }
+    $downloadArchitecture = if ($rid -eq 'win-arm64') { 'arm64' } else { 'x86_64' }
     $expectedMachine = if ($rid -eq 'win-arm64') { [uint16]0xAA64 } else { [uint16]0x8664 }
     $publish = Join-Path $artifactRoot "$rid/publish"
     $frontend = Join-Path $publish 'CodexTweaks.Windows.exe'
@@ -172,20 +174,39 @@ foreach ($rid in $RuntimeIdentifiers) {
     }
 
     if ($RequirePackages) {
-        $packId = "com.crzhichen.CodexTweaks.$architecture"
         $channelName = "win-$architecture-$Channel"
         $releases = Join-Path $artifactRoot "$rid/releases"
-        $setup = Join-Path $releases "$packId-$Version-$channelName-Setup.exe"
+        $setup = Join-Path $releases "Codex-Tweaks-v${Version}-windows-Setup-${downloadArchitecture}.exe"
         if (-not (Test-Path $setup -PathType Leaf)) {
             throw "Missing versioned Velopack installer: $setup"
         }
-        if (@(Get-ChildItem $releases -Filter '*-full.nupkg' -File).Count -eq 0) {
-            throw "Missing Velopack full package: $rid"
+        $fullPackages = @(Get-ChildItem $releases -Filter '*-full.nupkg' -File)
+        if ($fullPackages.Count -ne 1) {
+            throw "Expected exactly one Velopack full package for $rid, found $($fullPackages.Count)."
         }
-        if (@(Get-ChildItem $releases -Filter "releases.$channelName.json" -File).Count -ne 1) {
+        $feeds = @(Get-ChildItem $releases -Filter "releases.$channelName.json" -File)
+        if ($feeds.Count -ne 1) {
             throw "Missing Velopack channel feed releases.$channelName.json"
         }
+        $expectedReleaseAssets += @(
+            (Split-Path -Leaf $setup),
+            $fullPackages[0].Name,
+            $feeds[0].Name
+        )
     }
 
     Write-Host "Verified $rid publish output."
+}
+
+if ($RequirePackages) {
+    $stagedRelease = Join-Path $artifactRoot 'release'
+    if (-not (Test-Path $stagedRelease -PathType Container)) {
+        throw "Missing staged Windows release directory: $stagedRelease"
+    }
+    $expected = @($expectedReleaseAssets | Sort-Object)
+    $actual = @(Get-ChildItem $stagedRelease -File | ForEach-Object Name | Sort-Object)
+    if (($actual -join "`n") -ne ($expected -join "`n")) {
+        throw "Unexpected staged Windows assets. Expected: $($expected -join ', '); actual: $($actual -join ', ')"
+    }
+    Write-Host "Verified exact staged Windows release asset set ($($actual.Count) files)."
 }


### PR DESCRIPTION
## Summary

- keep universal, arm64, and x86_64 macOS DMGs while dropping redundant checksum assets
- publish only the Windows installer, full update package, and modern channel feed for each architecture
- generate a bilingual Chinese/English download table with direct links for every supported system
- verify the exact staged Windows release asset set in CI

## Validation

- `mise run verify`
- `RELEASE_TAG=v3.0.0-beta.2 BUILD_NUMBER=1 mise run release`
- PowerShell parser checks for both Windows packaging scripts
- generated bilingual release body inspected for v3.0.0-beta.2
- staged diff and secret-pattern checks passed