### PR TITLE
fix: 修复 Windows 发布证书导入卡死

### DIFF
--- a/scripts/import-windows-signing-certificate.ps1
+++ b/scripts/import-windows-signing-certificate.ps1
@@ -1,8 +1,17 @@
 [CmdletBinding()]
-param()
+param(
+    [switch]$Worker,
+
+    [ValidateRange(30, 600)]
+    [int]$TimeoutSeconds = 120
+)
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
+
+function Write-SigningStage([string]$Message) {
+    Write-Host "[windows-signing] $Message"
+}
 
 $requiredVariables = @(
     'WINDOWS_SIGNING_PFX_BASE64',
@@ -17,6 +26,42 @@ foreach ($variableName in $requiredVariables) {
     }
 }
 
+if (-not $Worker) {
+    Write-SigningStage "Starting isolated non-interactive import with a $TimeoutSeconds-second timeout."
+    $pwshPath = (Get-Process -Id $PID).Path
+    $scriptPathArgument = '"' + $PSCommandPath.Replace('"', '\"') + '"'
+    $arguments = @(
+        '-NoLogo',
+        '-NoProfile',
+        '-NonInteractive',
+        '-File',
+        $scriptPathArgument,
+        '-Worker'
+    )
+    $process = Start-Process `
+        -FilePath $pwshPath `
+        -ArgumentList $arguments `
+        -NoNewWindow `
+        -PassThru
+    try {
+        if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+            $process.Kill($true)
+            throw "Windows signing identity import exceeded $TimeoutSeconds seconds."
+        }
+        if ($process.ExitCode -ne 0) {
+            throw "Windows signing identity import failed with exit code $($process.ExitCode)."
+        }
+    }
+    finally {
+        if (-not $process.HasExited) {
+            $process.Kill($true)
+        }
+        $process.Dispose()
+    }
+    Write-SigningStage 'Isolated import completed.'
+    exit 0
+}
+
 function Normalize-Fingerprint([string]$Value) {
     return ($Value.ToUpperInvariant() -replace '[^0-9A-F]', '')
 }
@@ -29,15 +74,15 @@ else {
 }
 $signingDirectory = Join-Path $runnerTemp ("codex-tweaks-signing-" + [guid]::NewGuid().ToString('N'))
 $pfxPath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.pfx'
-$certificatePath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.cer'
 New-Item -ItemType Directory -Force -Path $signingDirectory | Out-Null
 
+Write-SigningStage 'Decoding the encrypted certificate container.'
 $encodedPfx = $env:WINDOWS_SIGNING_PFX_BASE64 -replace '\s', ''
 [System.IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($encodedPfx))
 
+Write-SigningStage 'Loading the PFX into the current-user key store.'
 $keyStorageFlags = [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet `
-    -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet `
-    -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
+    -bor [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet
 $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
     $pfxPath,
     $env:CODE_SIGNING_EXPORT_PASSWORD,
@@ -46,6 +91,7 @@ $certificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]:
 if (-not $certificate.HasPrivateKey) {
     throw 'The Windows signing PFX does not contain a private key.'
 }
+Write-SigningStage 'PFX private key is available.'
 
 $actualSha256 = Normalize-Fingerprint ($certificate.GetCertHashString(
     [System.Security.Cryptography.HashAlgorithmName]::SHA256
@@ -54,32 +100,83 @@ $expectedSha256 = Normalize-Fingerprint $env:WINDOWS_SIGNING_CERT_SHA256
 if ($expectedSha256.Length -ne 64 -or $actualSha256 -ne $expectedSha256) {
     throw "Windows signing certificate SHA-256 mismatch. Expected $expectedSha256; actual $actualSha256."
 }
+Write-SigningStage 'Certificate SHA-256 fingerprint is verified.'
 
-$securePassword = ConvertTo-SecureString $env:CODE_SIGNING_EXPORT_PASSWORD -AsPlainText -Force
-$importedCertificate = Import-PfxCertificate `
-    -FilePath $pfxPath `
-    -CertStoreLocation 'Cert:\CurrentUser\My' `
-    -Password $securePassword `
-    -Exportable
-if ($null -eq $importedCertificate -or -not $importedCertificate.HasPrivateKey) {
-    throw 'The Windows signing certificate could not be imported with its private key.'
+$thumbprint = Normalize-Fingerprint $certificate.Thumbprint
+if ([string]::IsNullOrWhiteSpace($thumbprint)) {
+    throw 'The Windows signing certificate has no SHA-1 thumbprint.'
 }
 
-[System.IO.File]::WriteAllBytes(
-    $certificatePath,
+Write-SigningStage 'Adding the signing identity to CurrentUser/My without certificate cmdlets.'
+$myStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+    [System.Security.Cryptography.X509Certificates.StoreName]::My,
+    [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+)
+try {
+    $myStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    $myStore.Add($certificate)
+}
+finally {
+    $myStore.Close()
+    $myStore.Dispose()
+}
+
+Write-SigningStage 'Verifying the persisted signing identity and private key.'
+$myStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+    [System.Security.Cryptography.X509Certificates.StoreName]::My,
+    [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+)
+try {
+    $myStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
+    $storedCertificates = $myStore.Certificates.Find(
+        [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint,
+        $thumbprint,
+        $false
+    )
+    $storedCertificate = @($storedCertificates | Where-Object HasPrivateKey)[0]
+    if ($null -eq $storedCertificate) {
+        throw 'The Windows signing identity was not persisted with its private key.'
+    }
+}
+finally {
+    $myStore.Close()
+    $myStore.Dispose()
+}
+
+Write-SigningStage 'Adding the public certificate to CurrentUser/Root without certificate cmdlets.'
+$publicCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
     $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
 )
-Import-Certificate `
-    -FilePath $certificatePath `
-    -CertStoreLocation 'Cert:\CurrentUser\Root' `
-    | Out-Null
+$rootStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+    [System.Security.Cryptography.X509Certificates.StoreName]::Root,
+    [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+)
+try {
+    $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+    $rootStore.Add($publicCertificate)
+}
+finally {
+    $rootStore.Close()
+    $rootStore.Dispose()
+}
 
-$thumbprint = Normalize-Fingerprint $importedCertificate.Thumbprint
-if ([string]::IsNullOrWhiteSpace($thumbprint)) {
-    throw 'The imported Windows signing certificate has no SHA-1 thumbprint.'
+Write-SigningStage 'Verifying the offline trust chain.'
+$chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+try {
+    $chain.ChainPolicy.RevocationMode = `
+        [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+    $chain.ChainPolicy.VerificationFlags = `
+        [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+    if (-not $chain.Build($storedCertificate)) {
+        $chainErrors = @($chain.ChainStatus | ForEach-Object Status) -join ', '
+        throw "The Windows signing certificate is not trusted after import: $chainErrors"
+    }
+}
+finally {
+    $chain.Dispose()
 }
 
 Add-Content -Path $env:GITHUB_ENV -Value "WINDOWS_SIGNING_THUMBPRINT=$thumbprint"
 Add-Content -Path $env:GITHUB_ENV -Value "VPK_SIGN_PARAMS=/sha1 $thumbprint /s My /fd SHA256"
 
-Write-Host "Windows signing identity imported and SHA-256 verified: $actualSha256"
+Write-SigningStage 'Signing identity import, private-key persistence, fingerprint, and trust checks passed.'


### PR DESCRIPTION
## 变更内容

- 移除 Release runner 上可能卡死的 `Import-PfxCertificate` / `Import-Certificate` 路径，改用 .NET `X509Store` 非交互写入 `CurrentUser/My` 与 `CurrentUser/Root`
- 保留 PFX 私钥、SHA-256 指纹、持久化私钥和离线信任链校验，继续向 SignTool/Velopack 提供 SHA-1 thumbprint
- 在每个不含秘密的阶段输出进度，并通过隔离 `pwsh -NonInteractive` 子进程增加 120 秒硬超时和非零退出传播

## 失败诊断

- `v3.0.0-beta.3` Release run `32692730185` 的 Windows job 在证书导入脚本启动后 17 分 48 秒没有任何脚本输出，随后由人工取消
- 旧脚本没有阶段标记，完成后的日志只能将卡点限定在 PFX/证书存储导入路径；本修复替换其中两个可能交互/挂起的 cmdlet，并使后续卡点可直接定位

## 验证

- `mise run verify`（通过）
- PowerShell AST parser（通过）
- 无效 PFX 隔离进程 smoke：阶段日志可见、worker 失败立即传播为非零退出（通过）
- `git diff --cached --check` 与 staged sensitive-content scan（通过）

真实 PFX、CurrentUser 证书存储与 SignTool 产物验证将在下一个不可变 beta tag 的 Release runner 中完成。