### PR TITLE
fix: 稳定验证 Windows 自签名发布身份

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,10 @@ jobs:
         shell: pwsh
         run: ./scripts/build-windows.ps1 -Version $env:CI_VERSION -BuildNumber $env:GITHUB_RUN_NUMBER
 
+      - name: Smoke test non-interactive Windows signing import
+        shell: pwsh
+        run: ./scripts/test-windows-signing-certificate-import.ps1
+
       - name: Package unsigned per-user installers
         shell: pwsh
         run: ./scripts/package-windows.ps1 -Version $env:CI_VERSION -Channel beta

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Codex Tweaks 每 2 秒重新发现页面与包状态。注入使用产物指纹�
 - Windows x64：下载名称以 `-x86_64.exe` 结尾的安装器，适用于 Intel 与 AMD 64 位电脑。
 - Windows ARM64：下载名称以 `-arm64.exe` 结尾的安装器，适用于 Snapdragon 等 ARM64 电脑。
 
-macOS 打开 DMG 后将 Codex Tweaks 拖移到“应用程序”。发布版使用稳定的自签名证书，但未经 Apple Developer ID 签名和公证；如果系统阻止首次打开，请在“系统设置 → 隐私与安全性”中确认。Windows 安装器默认安装到当前用户目录，不弹出管理员权限；可从“设置 → 应用 → 已安装的应用”卸载。Windows 同样使用稳定的自签名证书，因此 SmartScreen 仍可能要求用户确认运行。Release 中的 Sparkle ZIP、`.nupkg`、`appcast.xml` 和 `releases.*.json` 仅供应用内自动更新使用，普通用户无需手动下载。
+macOS 打开 DMG 后将 Codex Tweaks 拖移到“应用程序”。发布版使用稳定的自签名证书，但未经 Apple Developer ID 签名和公证；如果系统阻止首次打开，请在“系统设置 → 隐私与安全性”中确认。Windows 安装器默认安装到当前用户目录，不弹出管理员权限；可从“设置 → 应用 → 已安装的应用”卸载。Windows 同样使用稳定的自签名证书，因此 SmartScreen 仍可能要求用户确认运行。该证书用于固定发布身份，不会写入 runner 的受信任根证书库；发布校验会精确匹配 signer SHA-256、拒绝文件哈希不一致，并以仅驻留内存的自定义信任链验证自签名证书。Release 中的 Sparkle ZIP、`.nupkg`、`appcast.xml` 和 `releases.*.json` 仅供应用内自动更新使用，普通用户无需手动下载。
 
 macOS 应用使用 Sparkle 读取 `updates` 分支上的 EdDSA 签名 appcast。正式版只接收无 channel 的条目，测试版同时接收 `beta` 条目；开启自动检查后，Sparkle 可在后台下载，并在应用退出时静默安装完整 App，不需要用户重新打开 GitHub 下载 DMG。更新必须同时通过 Sparkle EdDSA 签名和稳定的 macOS 代码签名身份校验。
 

--- a/scripts/import-windows-signing-certificate.ps1
+++ b/scripts/import-windows-signing-certificate.ps1
@@ -155,7 +155,7 @@ $certutilPath = (Get-Command certutil.exe -ErrorAction Stop).Source
 $certificatePathArgument = '"' + $certificatePath.Replace('"', '\"') + '"'
 $certutilProcess = Start-Process `
     -FilePath $certutilPath `
-    -ArgumentList @('-user', '-f', '-addstore', 'Root', $certificatePathArgument) `
+    -ArgumentList @('-user', '-f', '-silent', '-addstore', 'Root', $certificatePathArgument) `
     -NoNewWindow `
     -PassThru `
     -Wait

--- a/scripts/import-windows-signing-certificate.ps1
+++ b/scripts/import-windows-signing-certificate.ps1
@@ -74,7 +74,6 @@ else {
 }
 $signingDirectory = Join-Path $runnerTemp ("codex-tweaks-signing-" + [guid]::NewGuid().ToString('N'))
 $pfxPath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.pfx'
-$certificatePath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.cer'
 New-Item -ItemType Directory -Force -Path $signingDirectory | Out-Null
 
 Write-SigningStage 'Decoding the encrypted certificate container.'
@@ -144,68 +143,7 @@ finally {
     $myStore.Dispose()
 }
 
-Write-SigningStage 'Exporting the public certificate for trust-store import.'
-[System.IO.File]::WriteAllBytes(
-    $certificatePath,
-    $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
-)
-
-Write-SigningStage 'Adding the public certificate to CurrentUser/Root with non-interactive certutil.'
-$certutilPath = (Get-Command certutil.exe -ErrorAction Stop).Source
-$certificatePathArgument = '"' + $certificatePath.Replace('"', '\"') + '"'
-$certutilProcess = Start-Process `
-    -FilePath $certutilPath `
-    -ArgumentList @('-user', '-f', '-silent', '-addstore', 'Root', $certificatePathArgument) `
-    -NoNewWindow `
-    -PassThru `
-    -Wait
-try {
-    if ($certutilProcess.ExitCode -ne 0) {
-        throw "certutil failed to add the Windows signing certificate to CurrentUser/Root with exit code $($certutilProcess.ExitCode)."
-    }
-}
-finally {
-    $certutilProcess.Dispose()
-}
-
-Write-SigningStage 'Verifying the trusted public certificate in CurrentUser/Root.'
-$rootStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
-    [System.Security.Cryptography.X509Certificates.StoreName]::Root,
-    [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
-)
-try {
-    $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
-    $trustedCertificates = $rootStore.Certificates.Find(
-        [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint,
-        $thumbprint,
-        $false
-    )
-    if ($trustedCertificates.Count -eq 0) {
-        throw 'The Windows signing certificate was not persisted in CurrentUser/Root.'
-    }
-}
-finally {
-    $rootStore.Close()
-    $rootStore.Dispose()
-}
-
-Write-SigningStage 'Verifying the offline trust chain.'
-$chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
-try {
-    $chain.ChainPolicy.RevocationMode = `
-        [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
-    $chain.ChainPolicy.VerificationFlags = `
-        [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
-    if (-not $chain.Build($storedCertificate)) {
-        $chainErrors = @($chain.ChainStatus | ForEach-Object Status) -join ', '
-        throw "The Windows signing certificate is not trusted after import: $chainErrors"
-    }
-}
-finally {
-    $chain.Dispose()
-}
-
 Add-Content -Path $env:GITHUB_ENV -Value "WINDOWS_SIGNING_THUMBPRINT=$thumbprint"
 Add-Content -Path $env:GITHUB_ENV -Value "VPK_SIGN_PARAMS=/sha1 $thumbprint /s My /fd SHA256"
 
-Write-SigningStage 'Signing identity import, private-key persistence, fingerprint, and trust checks passed.'
+Write-SigningStage 'Signing identity import, private-key persistence, and fingerprint checks passed.'

--- a/scripts/import-windows-signing-certificate.ps1
+++ b/scripts/import-windows-signing-certificate.ps1
@@ -59,7 +59,7 @@ if (-not $Worker) {
         $process.Dispose()
     }
     Write-SigningStage 'Isolated import completed.'
-    exit 0
+    return
 }
 
 function Normalize-Fingerprint([string]$Value) {
@@ -74,6 +74,7 @@ else {
 }
 $signingDirectory = Join-Path $runnerTemp ("codex-tweaks-signing-" + [guid]::NewGuid().ToString('N'))
 $pfxPath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.pfx'
+$certificatePath = Join-Path $signingDirectory 'zgccrui-windows-code-signing.cer'
 New-Item -ItemType Directory -Force -Path $signingDirectory | Out-Null
 
 Write-SigningStage 'Decoding the encrypted certificate container.'
@@ -143,17 +144,45 @@ finally {
     $myStore.Dispose()
 }
 
-Write-SigningStage 'Adding the public certificate to CurrentUser/Root without certificate cmdlets.'
-$publicCertificate = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new(
+Write-SigningStage 'Exporting the public certificate for trust-store import.'
+[System.IO.File]::WriteAllBytes(
+    $certificatePath,
     $certificate.Export([System.Security.Cryptography.X509Certificates.X509ContentType]::Cert)
 )
+
+Write-SigningStage 'Adding the public certificate to CurrentUser/Root with non-interactive certutil.'
+$certutilPath = (Get-Command certutil.exe -ErrorAction Stop).Source
+$certificatePathArgument = '"' + $certificatePath.Replace('"', '\"') + '"'
+$certutilProcess = Start-Process `
+    -FilePath $certutilPath `
+    -ArgumentList @('-user', '-f', '-addstore', 'Root', $certificatePathArgument) `
+    -NoNewWindow `
+    -PassThru `
+    -Wait
+try {
+    if ($certutilProcess.ExitCode -ne 0) {
+        throw "certutil failed to add the Windows signing certificate to CurrentUser/Root with exit code $($certutilProcess.ExitCode)."
+    }
+}
+finally {
+    $certutilProcess.Dispose()
+}
+
+Write-SigningStage 'Verifying the trusted public certificate in CurrentUser/Root.'
 $rootStore = [System.Security.Cryptography.X509Certificates.X509Store]::new(
     [System.Security.Cryptography.X509Certificates.StoreName]::Root,
     [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
 )
 try {
-    $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
-    $rootStore.Add($publicCertificate)
+    $rootStore.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
+    $trustedCertificates = $rootStore.Certificates.Find(
+        [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint,
+        $thumbprint,
+        $false
+    )
+    if ($trustedCertificates.Count -eq 0) {
+        throw 'The Windows signing certificate was not persisted in CurrentUser/Root.'
+    }
 }
 finally {
     $rootStore.Close()

--- a/scripts/test-windows-signing-certificate-import.ps1
+++ b/scripts/test-windows-signing-certificate-import.ps1
@@ -65,6 +65,8 @@ $temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
 $pfxPath = Join-Path $temporaryRoot 'signing-smoke.pfx'
 $githubEnvironmentPath = Join-Path $temporaryRoot 'github-env'
 $signedExecutablePath = Join-Path $temporaryRoot 'codex-tweaks-backend-signed.exe'
+$tamperedExecutablePath = Join-Path $temporaryRoot 'codex-tweaks-backend-tampered.exe'
+. "$PSScriptRoot/windows-signing-verification.ps1"
 $password = [Convert]::ToBase64String(
     [System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)
 )
@@ -114,9 +116,6 @@ try {
     Remove-CertificateFromStore `
         ([System.Security.Cryptography.X509Certificates.StoreName]::My) `
         $thumbprint
-    Remove-CertificateFromStore `
-        ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
-        $thumbprint
 
     $env:WINDOWS_SIGNING_PFX_BASE64 = [Convert]::ToBase64String(
         [System.IO.File]::ReadAllBytes($pfxPath)
@@ -136,14 +135,6 @@ try {
     if ($null -eq $myCertificate) {
         throw 'The production import did not persist the private key in CurrentUser/My.'
     }
-    $rootCertificate = Get-CertificateFromStore `
-        ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
-        $thumbprint `
-        $false
-    if ($null -eq $rootCertificate) {
-        throw 'The production import did not persist the public certificate in CurrentUser/Root.'
-    }
-
     $githubEnvironment = @(Get-Content $githubEnvironmentPath)
     if ($githubEnvironment -notcontains "WINDOWS_SIGNING_THUMBPRINT=$thumbprint") {
         throw 'The production import did not publish the expected signing thumbprint.'
@@ -172,25 +163,37 @@ try {
         throw "SignTool failed with exit code $LASTEXITCODE."
     }
 
-    $signature = Get-AuthenticodeSignature -FilePath $signedExecutablePath
-    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
-        throw "The smoke-test Authenticode signature is not valid: $($signature.Status)."
+    Assert-AuthenticodeSigner $signedExecutablePath $sha256
+
+    Write-Host '[windows-signing-smoke] Tampering with the signed PE for a negative integrity test.'
+    Copy-Item $signedExecutablePath $tamperedExecutablePath
+    $tamperedBytes = [System.IO.File]::ReadAllBytes($tamperedExecutablePath)
+    if ($tamperedBytes.Length -le 1024) {
+        throw 'The smoke-test PE is unexpectedly small.'
     }
-    $actualSignerSha256 = Normalize-Fingerprint ($signature.SignerCertificate.GetCertHashString(
-        [System.Security.Cryptography.HashAlgorithmName]::SHA256
-    ))
-    if ($actualSignerSha256 -ne $sha256) {
-        throw 'The smoke-test Authenticode signer does not match the generated certificate.'
+    $tamperedBytes[1024] = $tamperedBytes[1024] -bxor 1
+    [System.IO.File]::WriteAllBytes($tamperedExecutablePath, $tamperedBytes)
+    $tamperedSignature = Get-AuthenticodeSignature -FilePath $tamperedExecutablePath
+    Write-Host "[windows-signing-smoke] Tampered Authenticode status: $($tamperedSignature.Status)"
+    if ($tamperedSignature.Status -ne [System.Management.Automation.SignatureStatus]::HashMismatch) {
+        throw "The tampered PE did not produce HashMismatch: $($tamperedSignature.Status)."
     }
-    Write-Host '[windows-signing-smoke] Import, private key, trust, signing, and signer checks passed.'
+    $strictVerifierRejectedTampering = $false
+    try {
+        Assert-AuthenticodeSigner $tamperedExecutablePath $sha256
+    }
+    catch {
+        $strictVerifierRejectedTampering = $true
+    }
+    if (-not $strictVerifierRejectedTampering) {
+        throw 'The production Authenticode verifier accepted the tampered PE.'
+    }
+    Write-Host '[windows-signing-smoke] Import, private key, signing, signer, and tamper checks passed.'
 }
 finally {
     if (-not [string]::IsNullOrWhiteSpace($thumbprint)) {
         Remove-CertificateFromStore `
             ([System.Security.Cryptography.X509Certificates.StoreName]::My) `
-            $thumbprint
-        Remove-CertificateFromStore `
-            ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
             $thumbprint
     }
     foreach ($name in $environmentNames) {

--- a/scripts/test-windows-signing-certificate-import.ps1
+++ b/scripts/test-windows-signing-certificate-import.ps1
@@ -1,0 +1,202 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Normalize-Fingerprint([string]$Value) {
+    return ($Value.ToUpperInvariant() -replace '[^0-9A-F]', '')
+}
+
+function Remove-CertificateFromStore(
+    [System.Security.Cryptography.X509Certificates.StoreName]$StoreName,
+    [string]$Thumbprint
+) {
+    $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+        $StoreName,
+        [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+    )
+    try {
+        $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite)
+        $matches = $store.Certificates.Find(
+            [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint,
+            $Thumbprint,
+            $false
+        )
+        foreach ($match in $matches) {
+            $store.Remove($match)
+        }
+    }
+    finally {
+        $store.Close()
+        $store.Dispose()
+    }
+}
+
+function Get-CertificateFromStore(
+    [System.Security.Cryptography.X509Certificates.StoreName]$StoreName,
+    [string]$Thumbprint,
+    [bool]$RequirePrivateKey
+) {
+    $store = [System.Security.Cryptography.X509Certificates.X509Store]::new(
+        $StoreName,
+        [System.Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser
+    )
+    try {
+        $store.Open([System.Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly)
+        $matches = $store.Certificates.Find(
+            [System.Security.Cryptography.X509Certificates.X509FindType]::FindByThumbprint,
+            $Thumbprint,
+            $false
+        )
+        return @($matches | Where-Object { -not $RequirePrivateKey -or $_.HasPrivateKey }) |
+            Select-Object -First 1
+    }
+    finally {
+        $store.Close()
+        $store.Dispose()
+    }
+}
+
+$root = Split-Path -Parent $PSScriptRoot
+$temporaryRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+    'codex-tweaks-signing-smoke-' + [guid]::NewGuid().ToString('N')
+)
+$pfxPath = Join-Path $temporaryRoot 'signing-smoke.pfx'
+$githubEnvironmentPath = Join-Path $temporaryRoot 'github-env'
+$signedExecutablePath = Join-Path $temporaryRoot 'codex-tweaks-backend-signed.exe'
+$password = [Convert]::ToBase64String(
+    [System.Security.Cryptography.RandomNumberGenerator]::GetBytes(32)
+)
+$securePassword = ConvertTo-SecureString $password -AsPlainText -Force
+$thumbprint = ''
+$environmentNames = @(
+    'WINDOWS_SIGNING_PFX_BASE64',
+    'CODE_SIGNING_EXPORT_PASSWORD',
+    'WINDOWS_SIGNING_CERT_SHA256',
+    'GITHUB_ENV',
+    'RUNNER_TEMP'
+)
+$previousEnvironment = @{}
+foreach ($name in $environmentNames) {
+    $previousEnvironment[$name] = [Environment]::GetEnvironmentVariable($name)
+}
+
+New-Item -ItemType Directory -Force -Path $temporaryRoot | Out-Null
+try {
+    Write-Host '[windows-signing-smoke] Generating an ephemeral code-signing certificate.'
+    $generatedCertificate = New-SelfSignedCertificate `
+        -Type CodeSigningCert `
+        -Subject 'CN=Codex Tweaks CI Signing Smoke' `
+        -CertStoreLocation 'Cert:\CurrentUser\My' `
+        -KeyAlgorithm RSA `
+        -KeyLength 2048 `
+        -HashAlgorithm SHA256 `
+        -KeyExportPolicy Exportable `
+        -NotAfter (Get-Date).AddDays(1)
+    $thumbprint = Normalize-Fingerprint $generatedCertificate.Thumbprint
+    if ([string]::IsNullOrWhiteSpace($thumbprint) -or -not $generatedCertificate.HasPrivateKey) {
+        throw 'The smoke-test certificate was not created with a private key.'
+    }
+
+    [System.IO.File]::WriteAllBytes(
+        $pfxPath,
+        $generatedCertificate.Export(
+            [System.Security.Cryptography.X509Certificates.X509ContentType]::Pfx,
+            $password
+        )
+    )
+    $sha256 = Normalize-Fingerprint ($generatedCertificate.GetCertHashString(
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256
+    ))
+
+    Write-Host '[windows-signing-smoke] Removing generation-time certificate-store entries.'
+    Remove-CertificateFromStore `
+        ([System.Security.Cryptography.X509Certificates.StoreName]::My) `
+        $thumbprint
+    Remove-CertificateFromStore `
+        ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
+        $thumbprint
+
+    $env:WINDOWS_SIGNING_PFX_BASE64 = [Convert]::ToBase64String(
+        [System.IO.File]::ReadAllBytes($pfxPath)
+    )
+    $env:CODE_SIGNING_EXPORT_PASSWORD = $password
+    $env:WINDOWS_SIGNING_CERT_SHA256 = $sha256
+    $env:GITHUB_ENV = $githubEnvironmentPath
+    $env:RUNNER_TEMP = $temporaryRoot
+
+    Write-Host '[windows-signing-smoke] Running the production import script.'
+    & "$PSScriptRoot/import-windows-signing-certificate.ps1" -TimeoutSeconds 30
+
+    $myCertificate = Get-CertificateFromStore `
+        ([System.Security.Cryptography.X509Certificates.StoreName]::My) `
+        $thumbprint `
+        $true
+    if ($null -eq $myCertificate) {
+        throw 'The production import did not persist the private key in CurrentUser/My.'
+    }
+    $rootCertificate = Get-CertificateFromStore `
+        ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
+        $thumbprint `
+        $false
+    if ($null -eq $rootCertificate) {
+        throw 'The production import did not persist the public certificate in CurrentUser/Root.'
+    }
+
+    $githubEnvironment = @(Get-Content $githubEnvironmentPath)
+    if ($githubEnvironment -notcontains "WINDOWS_SIGNING_THUMBPRINT=$thumbprint") {
+        throw 'The production import did not publish the expected signing thumbprint.'
+    }
+
+    Write-Host '[windows-signing-smoke] Signing and verifying a copied test PE.'
+    $sourceExecutable = Join-Path $root 'artifacts/windows/win-x64/publish/codex-tweaks-backend.exe'
+    if (-not (Test-Path $sourceExecutable -PathType Leaf)) {
+        throw "Missing Windows smoke-test executable: $sourceExecutable"
+    }
+    Copy-Item $sourceExecutable $signedExecutablePath
+
+    $signTool = Get-ChildItem `
+        (Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin') `
+        -Filter 'signtool.exe' `
+        -File `
+        -Recurse `
+        | Where-Object FullName -Match '\\x64\\signtool\.exe$' `
+        | Sort-Object FullName -Descending `
+        | Select-Object -First 1
+    if ($null -eq $signTool) {
+        throw 'SignTool was not found on the Windows runner.'
+    }
+    & $signTool.FullName sign /sha1 $thumbprint /s My /fd SHA256 $signedExecutablePath | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "SignTool failed with exit code $LASTEXITCODE."
+    }
+
+    $signature = Get-AuthenticodeSignature -FilePath $signedExecutablePath
+    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+        throw "The smoke-test Authenticode signature is not valid: $($signature.Status)."
+    }
+    $actualSignerSha256 = Normalize-Fingerprint ($signature.SignerCertificate.GetCertHashString(
+        [System.Security.Cryptography.HashAlgorithmName]::SHA256
+    ))
+    if ($actualSignerSha256 -ne $sha256) {
+        throw 'The smoke-test Authenticode signer does not match the generated certificate.'
+    }
+    Write-Host '[windows-signing-smoke] Import, private key, trust, signing, and signer checks passed.'
+}
+finally {
+    if (-not [string]::IsNullOrWhiteSpace($thumbprint)) {
+        Remove-CertificateFromStore `
+            ([System.Security.Cryptography.X509Certificates.StoreName]::My) `
+            $thumbprint
+        Remove-CertificateFromStore `
+            ([System.Security.Cryptography.X509Certificates.StoreName]::Root) `
+            $thumbprint
+    }
+    foreach ($name in $environmentNames) {
+        [Environment]::SetEnvironmentVariable($name, $previousEnvironment[$name])
+    }
+    if (Test-Path $temporaryRoot) {
+        Remove-Item -Recurse -Force $temporaryRoot
+    }
+}

--- a/scripts/verify-windows.ps1
+++ b/scripts/verify-windows.ps1
@@ -21,37 +21,11 @@ Set-StrictMode -Version Latest
 
 $root = Split-Path -Parent $PSScriptRoot
 $artifactRoot = Join-Path $root 'artifacts/windows'
+. "$PSScriptRoot/windows-signing-verification.ps1"
 
-function Normalize-Fingerprint([string]$Value) {
-    return ($Value.ToUpperInvariant() -replace '[^0-9A-F]', '')
-}
-
-$expectedSigningSha256 = Normalize-Fingerprint $ExpectedSigningCertificateSha256
+$expectedSigningSha256 = Normalize-WindowsSigningFingerprint $ExpectedSigningCertificateSha256
 if (-not [string]::IsNullOrWhiteSpace($expectedSigningSha256) -and $expectedSigningSha256.Length -ne 64) {
     throw 'ExpectedSigningCertificateSha256 must be a complete SHA-256 fingerprint.'
-}
-
-function Assert-AuthenticodeSigner([string]$Path, [string]$ExpectedSha256) {
-    if ([string]::IsNullOrWhiteSpace($ExpectedSha256)) {
-        return
-    }
-    if (-not (Test-Path $Path -PathType Leaf)) {
-        throw "Missing signed Windows artifact: $Path"
-    }
-
-    $signature = Get-AuthenticodeSignature -FilePath $Path
-    if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
-        throw "Authenticode signature is not valid for $Path`: $($signature.Status) $($signature.StatusMessage)"
-    }
-    if ($null -eq $signature.SignerCertificate) {
-        throw "Authenticode signer certificate is missing for $Path"
-    }
-    $actualSha256 = Normalize-Fingerprint ($signature.SignerCertificate.GetCertHashString(
-        [System.Security.Cryptography.HashAlgorithmName]::SHA256
-    ))
-    if ($actualSha256 -ne $ExpectedSha256) {
-        throw "Authenticode signer mismatch for $Path. Expected $ExpectedSha256; actual $actualSha256."
-    }
 }
 
 function Assert-PackageAuthenticodeSignatures(

--- a/scripts/windows-signing-verification.ps1
+++ b/scripts/windows-signing-verification.ps1
@@ -5,6 +5,49 @@ function Normalize-WindowsSigningFingerprint([string]$Value) {
     return ($Value.ToUpperInvariant() -replace '[^0-9A-F]', '')
 }
 
+function Assert-PinnedSelfSignedChain(
+    [System.Security.Cryptography.X509Certificates.X509Certificate2]$SignerCertificate,
+    [string]$Path
+) {
+    $systemChain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+    try {
+        $systemChain.ChainPolicy.RevocationMode = `
+            [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+        $systemChain.ChainPolicy.VerificationFlags = `
+            [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+        $systemChainBuilt = $systemChain.Build($SignerCertificate)
+        $systemChainStatuses = @($systemChain.ChainStatus | ForEach-Object Status)
+        Write-Host "[windows-signing-verify] System chain statuses: $($systemChainStatuses -join ', ')"
+        if ($systemChainBuilt `
+            -or $systemChainStatuses.Count -ne 1 `
+            -or $systemChainStatuses[0] -ne `
+                [System.Security.Cryptography.X509Certificates.X509ChainStatusFlags]::UntrustedRoot) {
+            throw "Authenticode reported an untrusted signature, but the system chain failure was not exactly UntrustedRoot for $Path."
+        }
+    }
+    finally {
+        $systemChain.Dispose()
+    }
+
+    $customChain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+    try {
+        $customChain.ChainPolicy.TrustMode = `
+            [System.Security.Cryptography.X509Certificates.X509ChainTrustMode]::CustomRootTrust
+        [void]$customChain.ChainPolicy.CustomTrustStore.Add($SignerCertificate)
+        $customChain.ChainPolicy.RevocationMode = `
+            [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+        $customChain.ChainPolicy.VerificationFlags = `
+            [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+        if (-not $customChain.Build($SignerCertificate)) {
+            $chainErrors = @($customChain.ChainStatus | ForEach-Object Status) -join ', '
+            throw "The pinned self-signed Authenticode chain is invalid for $Path`: $chainErrors"
+        }
+    }
+    finally {
+        $customChain.Dispose()
+    }
+}
+
 function Assert-AuthenticodeSigner([string]$Path, [string]$ExpectedSha256) {
     if ([string]::IsNullOrWhiteSpace($ExpectedSha256)) {
         return
@@ -33,23 +76,11 @@ function Assert-AuthenticodeSigner([string]$Path, [string]$ExpectedSha256) {
             return
         }
         ([System.Management.Automation.SignatureStatus]::NotTrusted) {
-            $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
-            try {
-                $chain.ChainPolicy.TrustMode = `
-                    [System.Security.Cryptography.X509Certificates.X509ChainTrustMode]::CustomRootTrust
-                [void]$chain.ChainPolicy.CustomTrustStore.Add($signature.SignerCertificate)
-                $chain.ChainPolicy.RevocationMode = `
-                    [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
-                $chain.ChainPolicy.VerificationFlags = `
-                    [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
-                if (-not $chain.Build($signature.SignerCertificate)) {
-                    $chainErrors = @($chain.ChainStatus | ForEach-Object Status) -join ', '
-                    throw "The pinned self-signed Authenticode chain is invalid for $Path`: $chainErrors"
-                }
-            }
-            finally {
-                $chain.Dispose()
-            }
+            Assert-PinnedSelfSignedChain $signature.SignerCertificate $Path
+            return
+        }
+        ([System.Management.Automation.SignatureStatus]::UnknownError) {
+            Assert-PinnedSelfSignedChain $signature.SignerCertificate $Path
             return
         }
         default {

--- a/scripts/windows-signing-verification.ps1
+++ b/scripts/windows-signing-verification.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+function Normalize-WindowsSigningFingerprint([string]$Value) {
+    return ($Value.ToUpperInvariant() -replace '[^0-9A-F]', '')
+}
+
+function Assert-AuthenticodeSigner([string]$Path, [string]$ExpectedSha256) {
+    if ([string]::IsNullOrWhiteSpace($ExpectedSha256)) {
+        return
+    }
+    if (-not (Test-Path $Path -PathType Leaf)) {
+        throw "Missing signed Windows artifact: $Path"
+    }
+
+    $signature = Get-AuthenticodeSignature -FilePath $Path
+    Write-Host "[windows-signing-verify] Authenticode status for $(Split-Path -Leaf $Path): $($signature.Status)"
+    if ($null -eq $signature.SignerCertificate) {
+        throw "Authenticode signer certificate is missing for $Path"
+    }
+
+    $actualSha256 = Normalize-WindowsSigningFingerprint (
+        $signature.SignerCertificate.GetCertHashString(
+            [System.Security.Cryptography.HashAlgorithmName]::SHA256
+        )
+    )
+    if ($actualSha256 -ne $ExpectedSha256) {
+        throw "Authenticode signer mismatch for $Path. Expected $ExpectedSha256; actual $actualSha256."
+    }
+
+    switch ($signature.Status) {
+        ([System.Management.Automation.SignatureStatus]::Valid) {
+            return
+        }
+        ([System.Management.Automation.SignatureStatus]::NotTrusted) {
+            $chain = [System.Security.Cryptography.X509Certificates.X509Chain]::new()
+            try {
+                $chain.ChainPolicy.TrustMode = `
+                    [System.Security.Cryptography.X509Certificates.X509ChainTrustMode]::CustomRootTrust
+                [void]$chain.ChainPolicy.CustomTrustStore.Add($signature.SignerCertificate)
+                $chain.ChainPolicy.RevocationMode = `
+                    [System.Security.Cryptography.X509Certificates.X509RevocationMode]::NoCheck
+                $chain.ChainPolicy.VerificationFlags = `
+                    [System.Security.Cryptography.X509Certificates.X509VerificationFlags]::NoFlag
+                if (-not $chain.Build($signature.SignerCertificate)) {
+                    $chainErrors = @($chain.ChainStatus | ForEach-Object Status) -join ', '
+                    throw "The pinned self-signed Authenticode chain is invalid for $Path`: $chainErrors"
+                }
+            }
+            finally {
+                $chain.Dispose()
+            }
+            return
+        }
+        default {
+            throw "Authenticode signature failed strict validation for $Path`: $($signature.Status) $($signature.StatusMessage)"
+        }
+    }
+}


### PR DESCRIPTION
## 变更

- Windows 发布只将稳定 PFX 私钥身份导入 `CurrentUser/My`，保留隔离非交互进程、超时、私钥持久化与 SHA-256 指纹校验，不再写入受保护的 Root store
- 抽取生产 Authenticode 验证器：精确匹配 signer SHA-256，严格拒绝未签名、哈希不一致、不支持格式、不兼容与未知错误
- 对自签名证书仅允许明确的 `NotTrusted`，随后用内存 `CustomRootTrust`、禁用联网吊销检查且无宽松 verification flags 验证完整链
- 普通 Windows PR CI 使用临时自签名 PFX 调用生产导入、实际 SignTool 签名 PE、复用生产验证器，并篡改已签名 PE 验证 `HashMismatch` 必须被拒绝；finally 清理 My store 与临时文件
- README 明确自签名证书固定发布身份但不代表公共信任

## 验证

- `mise run workflows:lint`
- `mise run verify`
- PowerShell AST parse（全部相关脚本）
- staged diff/secret-pattern scan

## 背景

`v3.0.0-beta.4` 证明 PFX、CurrentUser/My 私钥与指纹校验均在亚秒级完成；卡点来自向受保护 Root store 写入。稳定自签名发布只需要固定 signer 身份与严格完整性校验，因此移除不必要且会触发交互的系统信任写入。