### PR TITLE
fix: 修复 Windows Logo 资源打包与显示

### DIFF
--- a/scripts/verify-windows.ps1
+++ b/scripts/verify-windows.ps1
@@ -185,11 +185,19 @@ foreach ($rid in $RuntimeIdentifiers) {
     $frontend = Join-Path $publish 'CodexTweaks.Windows.exe'
     $backend = Join-Path $publish 'codex-tweaks-backend.exe'
     $xamlResources = Join-Path $publish 'CodexTweaks.Windows.pri'
+    $appIcon = Join-Path $publish 'Assets/CodexTweaks.ico'
+    $appLogo = Join-Path $publish 'Assets/CodexTweaks.png'
 
     Assert-PeMachine $frontend $expectedMachine
     Assert-PeMachine $backend $expectedMachine
     if (-not (Test-Path $xamlResources -PathType Leaf)) {
         throw "WinUI XAML resource index is missing: $rid"
+    }
+    if (-not (Test-Path $appIcon -PathType Leaf)) {
+        throw "Windows application icon is missing: $rid"
+    }
+    if (-not (Test-Path $appLogo -PathType Leaf)) {
+        throw "Windows application logo is missing: $rid"
     }
     if (-not (Test-Path (Join-Path $publish 'Tweaks/packages') -PathType Container)) {
         throw "Bundled tweak packages are missing: $rid"

--- a/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
+++ b/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
@@ -42,6 +42,18 @@
     <AssemblyMetadata Include="CodexTweaksBuildNumber" Value="$(CodexTweaksBuildNumber)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Content Remove="Assets\CodexTweaks.ico;Assets\CodexTweaks.png" />
+    <Content Include="Assets\CodexTweaks.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+    <Content Include="Assets\CodexTweaks.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+
   <Target Name="CopyXamlPriToPublishDirectory" AfterTargets="Publish">
     <PropertyGroup>
       <XamlPriFile>$(TargetDir)$(AssemblyName).pri</XamlPriFile>

--- a/windows/CodexTweaks.Windows/MainWindow.xaml
+++ b/windows/CodexTweaks.Windows/MainWindow.xaml
@@ -22,12 +22,12 @@
                 <ColumnDefinition Width="Auto" />
                 <ColumnDefinition Width="*" />
             </Grid.ColumnDefinitions>
-            <FontIcon
-                Width="16"
-                Height="16"
-                FontSize="14"
-                Glyph="&#xE943;"
-                Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}" />
+            <Image
+                Width="18"
+                Height="18"
+                AutomationProperties.AccessibilityView="Raw"
+                Source="ms-appx:///Assets/CodexTweaks.png"
+                Stretch="UniformToFill" />
             <TextBlock
                 x:Name="AppTitleText"
                 Grid.Column="1"


### PR DESCRIPTION
## 变更内容

- 将 Windows ICO 与 PNG Logo 显式复制到 build/publish 输出目录。
- 将标题栏占位 FontIcon 替换为真实 Codex Tweaks Logo。
- 扩展 Windows 发布验证，检查 x64 与 ARM64 输出中的图标和 Logo 资源。

## 验证

- `mise run verify`
- `xmllint --noout windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj windows/CodexTweaks.Windows/MainWindow.xaml`
- PowerShell Parser 校验 `scripts/verify-windows.ps1`
- `git diff --check`

本机为 macOS，无法运行 WinUI 3 的 Windows-only XamlCompiler/mt.exe；Windows x64/ARM64 build、package 与 verify 由 GitHub Windows CI 覆盖。