### PR TITLE
fix: 修复 Windows 包构建状态与操作

### DIFF
--- a/backend/internal/core/controller_test.go
+++ b/backend/internal/core/controller_test.go
@@ -83,6 +83,67 @@ func TestControllerUsesGoDefaultsReadsSkillAndDisablesNewPackages(t *testing.T) 
 	}
 }
 
+func TestControllerKeepsManualBuildAvailableForLocalPackageChanges(t *testing.T) {
+	root := t.TempDir()
+	controller, err := NewController(
+		InitializeParams{
+			ApplicationSupportDirectory: filepath.Join(root, "support"),
+			CacheDirectory:              filepath.Join(root, "cache"),
+			CurrentVersion:              "0.1.0",
+			BuildNumber:                 "1",
+		},
+		nil,
+		ControllerDependencies{DisableBackground: true},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer controller.cancel()
+
+	directory := makeStorePackage(t, controller.store, "local-package", "local-package", "1.0.0", 0, nil, "")
+	if err := controller.ReloadPackages(); err != nil {
+		t.Fatal(err)
+	}
+	activateTestBuild(t, controller.store, controller.packages[0], "local-js", "")
+	controller.mu.Lock()
+	controller.nodeEnvironment = &NodeEnvironment{Version: "v24.0.0"}
+	controller.mu.Unlock()
+	if err := controller.ReloadPackages(); err != nil {
+		t.Fatal(err)
+	}
+
+	assertBuildState := func(disposition BuildDisposition) {
+		t.Helper()
+		view := controller.Snapshot().Packages[0]
+		if view.BuildDisposition != disposition || !view.AvailableActions.Build {
+			t.Fatalf("build state = %s, available = %t; want %s and available", view.BuildDisposition, view.AvailableActions.Build, disposition)
+		}
+	}
+	assertBuildState(BuildCurrent)
+
+	if err := os.WriteFile(filepath.Join(directory, "src", "index.js"), []byte("changed"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.ReloadPackages(); err != nil {
+		t.Fatal(err)
+	}
+	assertBuildState(BuildSourceChanged)
+
+	var manifest PackageManifest
+	manifestPath := filepath.Join(directory, "package.json")
+	if err := readJSON(manifestPath, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.Version = "1.1.0"
+	if err := writeJSONAtomic(manifestPath, manifest); err != nil {
+		t.Fatal(err)
+	}
+	if err := controller.ReloadPackages(); err != nil {
+		t.Fatal(err)
+	}
+	assertBuildState(BuildVersionUpdate)
+}
+
 func TestControllerLocalInstallEmitsSnapshotContainingPackage(t *testing.T) {
 	root := t.TempDir()
 	events := make(chan AppSnapshot, 8)

--- a/windows/CodexTweaks.Windows/Models/BackendModels.cs
+++ b/windows/CodexTweaks.Windows/Models/BackendModels.cs
@@ -77,6 +77,9 @@ internal sealed class PackageView
     [JsonPropertyName("buildDisposition")]
     public string BuildDisposition { get; init; } = string.Empty;
 
+    [JsonPropertyName("hasDependencies")]
+    public bool HasDependencies { get; init; }
+
     [JsonPropertyName("canInstallMissingDependencies")]
     public bool CanInstallMissingDependencies { get; init; }
 

--- a/windows/CodexTweaks.Windows/Pages/PackagesPage.xaml.cs
+++ b/windows/CodexTweaks.Windows/Pages/PackagesPage.xaml.cs
@@ -493,9 +493,8 @@ public sealed partial class PackagesPage : Page
 
     private async void BuildPackageButton_Click(object sender, RoutedEventArgs e)
     {
-        if (sender is Button { DataContext: PackageRowViewModel row } button)
+        if (sender is Button { DataContext: PackageRowViewModel row })
         {
-            button.IsEnabled = false;
             await Host.RunBackendAsync("buildPackage", new { packageID = row.Id });
         }
     }
@@ -623,11 +622,21 @@ internal sealed class PackageRowViewModel : INotifyPropertyChanged
         CanUpdate = package.AvailableActions.UpdateManagedPackage;
         OpenDirectoryLabel = host.Text(PresentationTextKey.PackagesOpenDirectory);
         CanOpenDirectory = package.AvailableActions.OpenDirectory;
-        BuildLabel = host.Text(snapshot.BuildingPackageIds.Contains(package.Id)
-            ? PresentationTextKey.PackagesBuilding
-            : package.BuildDisposition == "current"
-                ? PresentationTextKey.PackagesRebuild
-                : PresentationTextKey.PackagesBuild);
+        BuildLabel = snapshot.BuildingPackageIds.Contains(package.Id)
+            ? host.Text(PresentationTextKey.PackagesBuilding)
+            : package.BuildDisposition switch
+            {
+                "notBuilt" => host.Text(package.HasDependencies
+                    ? PresentationTextKey.PackagesInstallAndBuild
+                    : PresentationTextKey.PackagesBuild),
+                "versionUpdate" => host.Text(
+                    PresentationTextKey.PackagesUpdateToVersion,
+                    ("version", package.DisplayVersion)),
+                "dependencyUpdate" => host.Text(PresentationTextKey.PackagesSyncAndBuild),
+                "sourceChanged" or "compilerUpdate" => host.Text(PresentationTextKey.PackagesUpdateBuild),
+                "current" => host.Text(PresentationTextKey.PackagesRebuild),
+                _ => host.Text(PresentationTextKey.PackagesCannotBuild),
+            };
         CanBuild = package.AvailableActions.Build;
         MessagesText = string.Join(Environment.NewLine, host.PackageMessages(package));
         MessagesVisibility = string.IsNullOrWhiteSpace(MessagesText)


### PR DESCRIPTION
## 变更内容

- 为 Windows 包视图补齐依赖状态字段，并按构建状态显示安装构建、版本更新、依赖同步、源码更新和重新构建文案。
- 保留后端构建动作作为按钮可用性的唯一状态来源，避免点击后本地永久禁用按钮。
- 增加 Go 回归测试，确认本地包在源码、版本变化后仍可手动构建。

## 验证

- `mise run generate`
- `go test ./internal/core -run TestControllerKeepsManualBuildAvailableForLocalPackageChanges -count=1`
- `mise run verify`（提交前对本轮完整变更集通过）
- `git diff --cached --check`
- staged diff 敏感信息扫描通过