### PR TITLE
fix: 修复 Windows 更新检查流程

### DIFF
--- a/windows/CodexTweaks.Windows/MainWindow.xaml.cs
+++ b/windows/CodexTweaks.Windows/MainWindow.xaml.cs
@@ -33,6 +33,7 @@ public sealed partial class MainWindow : Window
     private Task? _shutdownTask;
     private string _section = InitialSection();
     private bool _started;
+    private bool _checkingUpdate;
     private bool _applyingUpdate;
     private bool _promptingUpdate;
     private bool _selectingNavigation;
@@ -97,6 +98,8 @@ public sealed partial class MainWindow : Window
 
     internal VelopackUpdateResult? VelopackResult => _velopackResult;
 
+    internal bool CheckingUpdate => _checkingUpdate || _snapshot?.Update.Checking == true;
+
     internal bool ApplyingUpdate => _applyingUpdate;
 
     private void ConfigureWindow()
@@ -158,7 +161,7 @@ public sealed partial class MainWindow : Window
             ApplySnapshot(snapshot);
             if (snapshot.Update.AutoCheck)
             {
-                await CheckVelopackAsync(promptForUpdate: true);
+                await CheckUpdatesAsync(refreshBackend: false);
             }
         }
         catch (Exception exception)
@@ -570,16 +573,39 @@ public sealed partial class MainWindow : Window
         }
     }
 
-    internal async Task CheckUpdatesAsync()
+    internal Task CheckUpdatesAsync() => CheckUpdatesAsync(refreshBackend: true);
+
+    private async Task CheckUpdatesAsync(bool refreshBackend)
     {
+        if (_checkingUpdate || _applyingUpdate)
+        {
+            return;
+        }
+
+        _checkingUpdate = true;
         try
         {
-            await _backend.SendAsync("checkAppUpdate", new { prompt = false });
-            await CheckVelopackAsync(promptForUpdate: true);
+            RenderCurrentPage();
+            NotifyTrayStateChanged();
+            if (refreshBackend)
+            {
+                await _backend.SendAsync("checkAppUpdate", new { prompt = false });
+            }
+            _velopackResult = await _velopack.CheckAsync(
+                Snapshot.Update.Channel,
+                Snapshot.Presentation.Platform.Architecture,
+                Snapshot.Presentation.Platform.RepositoryURL);
+            await PromptForUpdateAsync();
         }
         catch (Exception exception)
         {
             ShowError(Text(PresentationTextKey.UpdateCheckFailed, ("message", exception.Message)));
+        }
+        finally
+        {
+            _checkingUpdate = false;
+            RenderCurrentPage();
+            NotifyTrayStateChanged();
         }
     }
 
@@ -645,20 +671,6 @@ public sealed partial class MainWindow : Window
             ShowError(Text(PresentationTextKey.UpdateInstallFailed, ("message", exception.Message)));
             RenderCurrentPage();
             NotifyTrayStateChanged();
-        }
-    }
-
-    private async Task CheckVelopackAsync(bool promptForUpdate)
-    {
-        _velopackResult = await _velopack.CheckAsync(
-            Snapshot.Update.Channel,
-            Snapshot.Presentation.Platform.Architecture,
-            Snapshot.Presentation.Platform.RepositoryURL);
-        RenderCurrentPage();
-        NotifyTrayStateChanged();
-        if (promptForUpdate)
-        {
-            await PromptForUpdateAsync();
         }
     }
 

--- a/windows/CodexTweaks.Windows/Pages/UpdatesPage.xaml.cs
+++ b/windows/CodexTweaks.Windows/Pages/UpdatesPage.xaml.cs
@@ -50,11 +50,15 @@ public sealed partial class UpdatesPage : Page
                 Tag = "beta",
             });
             ChannelComboBox.SelectedIndex = snapshot.Update.Channel == "beta" ? 1 : 0;
-            ChannelComboBox.IsEnabled = snapshot.Presentation.Actions.SetUpdatePreferences;
+            ChannelComboBox.IsEnabled = snapshot.Presentation.Actions.SetUpdatePreferences
+                && !host.CheckingUpdate
+                && !host.ApplyingUpdate;
 
             AutoCheckTitle.Text = host.Text(PresentationTextKey.UpdateAutoCheck);
             AutoCheckToggle.IsOn = snapshot.Update.AutoCheck;
-            AutoCheckToggle.IsEnabled = snapshot.Presentation.Actions.SetUpdatePreferences;
+            AutoCheckToggle.IsEnabled = snapshot.Presentation.Actions.SetUpdatePreferences
+                && !host.CheckingUpdate
+                && !host.ApplyingUpdate;
 
             CurrentVersionLabel.Text = host.Text(PresentationTextKey.UpdateCurrentVersion);
             CurrentVersionValue.Text = snapshot.Update.CurrentVersion;
@@ -65,10 +69,12 @@ public sealed partial class UpdatesPage : Page
 
             RenderStatus(host, snapshot);
 
-            CheckButtonText.Text = host.Text(snapshot.Update.Checking || host.ApplyingUpdate
+            CheckButtonText.Text = host.Text(host.CheckingUpdate || host.ApplyingUpdate
                 ? PresentationTextKey.UpdateChecking
                 : PresentationTextKey.UpdateCheck);
-            CheckButton.IsEnabled = snapshot.Presentation.Actions.CheckAppUpdate && !host.ApplyingUpdate;
+            CheckButton.IsEnabled = snapshot.Presentation.Actions.CheckAppUpdate
+                && !host.CheckingUpdate
+                && !host.ApplyingUpdate;
 
             InstallButton.Visibility = host.VelopackResult is { Installed: true, Version: not null }
                 ? Visibility.Visible
@@ -78,7 +84,9 @@ public sealed partial class UpdatesPage : Page
                     ? PresentationTextKey.UpdateApplyProgress
                     : PresentationTextKey.UpdateInstall, ("version", version))
                 : string.Empty;
-            InstallButton.IsEnabled = snapshot.Presentation.Actions.InstallAppUpdate && !host.ApplyingUpdate;
+            InstallButton.IsEnabled = snapshot.Presentation.Actions.InstallAppUpdate
+                && !host.CheckingUpdate
+                && !host.ApplyingUpdate;
 
             ReleaseButton.Visibility = host.VelopackResult is not { Installed: true, Version: not null }
                                        && snapshot.Update.LatestRelease?.HtmlUrl is not null
@@ -95,6 +103,14 @@ public sealed partial class UpdatesPage : Page
     private void RenderStatus(MainWindow host, BackendAppSnapshot snapshot)
     {
         UpdateStatusInfo.IsOpen = false;
+        if (host.CheckingUpdate)
+        {
+            UpdateStatusInfo.Severity = InfoBarSeverity.Informational;
+            UpdateStatusInfo.Title = host.Text(PresentationTextKey.UpdateChecking);
+            UpdateStatusInfo.Message = string.Empty;
+            UpdateStatusInfo.IsOpen = true;
+            return;
+        }
         if (!string.IsNullOrWhiteSpace(snapshot.Update.LastError))
         {
             UpdateStatusInfo.Severity = InfoBarSeverity.Error;

--- a/windows/CodexTweaks.Windows/Services/TrayIconService.cs
+++ b/windows/CodexTweaks.Windows/Services/TrayIconService.cs
@@ -199,13 +199,14 @@ internal sealed class TrayIconService : IDisposable
             ("version", updateVersion ?? string.Empty));
         _installUpdateItem.Visible = !string.IsNullOrWhiteSpace(updateVersion);
         _installUpdateItem.Enabled = actions?.InstallAppUpdate == true
+            && !_window.CheckingUpdate
             && !_window.ApplyingUpdate;
         _checkUpdatesItem.Text = Text(
-            snapshot?.Update.Checking == true
+            _window.CheckingUpdate
                 ? PresentationTextKey.UpdateChecking
                 : PresentationTextKey.UpdateCheck);
         _checkUpdatesItem.Enabled = actions?.CheckAppUpdate == true
-            && snapshot?.Update.Checking != true
+            && !_window.CheckingUpdate
             && !_window.ApplyingUpdate;
         _quitItem.Text = Text(PresentationTextKey.MenuQuit);
 

--- a/windows/CodexTweaks.Windows/Services/VelopackUpdateService.cs
+++ b/windows/CodexTweaks.Windows/Services/VelopackUpdateService.cs
@@ -9,8 +9,9 @@ internal sealed record VelopackUpdateResult(bool Installed, string? Version, str
 
 internal sealed class VelopackUpdateService
 {
-    private UpdateManager? _manager;
-    private UpdateInfo? _pending;
+    private sealed record PendingUpdate(UpdateManager Manager, UpdateInfo Update);
+
+    private PendingUpdate? _pending;
 
     internal async Task<VelopackUpdateResult> CheckAsync(
         string channel,
@@ -26,20 +27,20 @@ internal sealed class VelopackUpdateService
                 ExplicitChannel = $"win-{ridArchitecture}-{channel}",
                 AllowVersionDowngrade = true,
             };
-            _manager = string.IsNullOrWhiteSpace(localSource)
+            var manager = string.IsNullOrWhiteSpace(localSource)
                 ? new UpdateManager(
                     new GithubSource(repositoryUrl, null, channel == "beta"),
                     options)
                 : new UpdateManager(localSource, options);
-            _pending = await _manager.CheckForUpdatesAsync();
+            var update = await manager.CheckForUpdatesAsync();
+            _pending = update is null ? null : new PendingUpdate(manager, update);
             return new VelopackUpdateResult(
                 true,
-                _pending?.TargetFullRelease.Version.ToString(),
+                update?.TargetFullRelease.Version.ToString(),
                 null);
         }
         catch (NotInstalledException)
         {
-            _manager = null;
             _pending = null;
             return new VelopackUpdateResult(false, null, null);
         }
@@ -52,19 +53,18 @@ internal sealed class VelopackUpdateService
 
     internal async Task DownloadAsync(Action<int> progress)
     {
-        var manager = _manager ?? throw new InvalidOperationException(
-            PresentationFallback.Text(PresentationTextKey.UpdateCheckFirst));
-        var update = _pending ?? throw new InvalidOperationException(
+        var pending = _pending ?? throw new InvalidOperationException(
             PresentationFallback.Text(PresentationTextKey.UpdateNoneAvailable));
-        await manager.DownloadUpdatesAsync(update, progress, CancellationToken.None);
+        await pending.Manager.DownloadUpdatesAsync(
+            pending.Update,
+            progress,
+            CancellationToken.None);
     }
 
     internal void ApplyAndRestart()
     {
-        var manager = _manager ?? throw new InvalidOperationException(
-            PresentationFallback.Text(PresentationTextKey.UpdateCheckFirst));
-        var update = _pending ?? throw new InvalidOperationException(
+        var pending = _pending ?? throw new InvalidOperationException(
             PresentationFallback.Text(PresentationTextKey.UpdateNoneAvailable));
-        manager.ApplyUpdatesAndRestart(update);
+        pending.Manager.ApplyUpdatesAndRestart(pending.Update);
     }
 }


### PR DESCRIPTION
## 变更内容

- 统一 Windows 手动与自动更新检查入口，显式维护检查中状态，避免重复检查或检查/安装并发。
- 检查和应用期间同步禁用更新页偏好、检查/安装按钮及托盘操作，并展示一致的检查中提示。
- 将 Velopack 的 `UpdateManager` 与对应 `UpdateInfo` 成对保存，确保下载和应用使用同一次检查结果。

## 验证

- `mise run generate`
- `mise run verify`（在本轮最终组合树上通过）
- `git diff --cached --check`
- 生成文件漂移检查通过
- staged diff 敏感信息扫描通过

Windows x64/ARM64 self-contained 构建、Velopack 打包与校验由本 PR 的 Windows CI 覆盖。