### PR TITLE
refactor: 使用原生 WinUI 托盘菜单

### DIFF
--- a/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
+++ b/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FrameworkReference Include="Microsoft.WindowsDesktop.App.WindowsForms" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.2" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>

--- a/windows/CodexTweaks.Windows/Services/TrayIconService.cs
+++ b/windows/CodexTweaks.Windows/Services/TrayIconService.cs
@@ -1,8 +1,10 @@
-using System.ComponentModel;
 using System.Drawing;
 using CodexTweaks.Windows.Generated;
+using H.NotifyIcon;
+using H.NotifyIcon.Core;
 using Microsoft.UI.Dispatching;
-using Forms = System.Windows.Forms;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 
 namespace CodexTweaks.Windows.Services;
 
@@ -14,26 +16,23 @@ internal sealed class TrayIconService : IDisposable
     private readonly MainWindow _window;
     private readonly Func<Task> _quitAsync;
     private readonly DispatcherQueue _dispatcherQueue;
-    private readonly Forms.ContextMenuStrip _menu = new()
-    {
-        ShowCheckMargin = true,
-        ShowImageMargin = false,
-    };
-    private readonly Forms.NotifyIcon _notifyIcon = new();
-    private readonly Icon _icon;
-    private readonly Forms.ToolStripMenuItem _statusItem = new() { Enabled = false };
-    private readonly Forms.ToolStripMenuItem _detailItem = new() { Enabled = false };
-    private readonly Forms.ToolStripMenuItem _showItem = new();
-    private readonly Forms.ToolStripMenuItem _openCodexItem = new();
-    private readonly Forms.ToolStripMenuItem _restartCodexItem = new();
-    private readonly Forms.ToolStripMenuItem _enabledItem = new() { CheckOnClick = false };
-    private readonly Forms.ToolStripMenuItem _reinjectItem = new();
-    private readonly Forms.ToolStripMenuItem _managePackagesItem = new();
-    private readonly Forms.ToolStripMenuItem _copySkillItem = new();
-    private readonly Forms.ToolStripMenuItem _viewLogsItem = new();
-    private readonly Forms.ToolStripMenuItem _installUpdateItem = new();
-    private readonly Forms.ToolStripMenuItem _checkUpdatesItem = new();
-    private readonly Forms.ToolStripMenuItem _quitItem = new();
+    private readonly MenuFlyout _menu = new();
+    private readonly TaskbarIcon _notifyIcon = new();
+    private readonly XamlUICommand _showWindowCommand = new();
+    private readonly XamlUICommand _refreshMenuCommand = new();
+    private readonly MenuFlyoutItem _statusItem = CreateMenuItem(Symbol.Link, false);
+    private readonly MenuFlyoutItem _detailItem = new() { IsEnabled = false };
+    private readonly MenuFlyoutItem _showItem = CreateMenuItem(Symbol.Home);
+    private readonly MenuFlyoutItem _openCodexItem = CreateMenuItem(Symbol.Play);
+    private readonly MenuFlyoutItem _restartCodexItem = CreateMenuItem(Symbol.Refresh);
+    private readonly ToggleMenuFlyoutItem _enabledItem = new();
+    private readonly MenuFlyoutItem _reinjectItem = CreateMenuItem(Symbol.Sync);
+    private readonly MenuFlyoutItem _managePackagesItem = CreateMenuItem(Symbol.Library);
+    private readonly MenuFlyoutItem _copySkillItem = CreateMenuItem(Symbol.Copy);
+    private readonly MenuFlyoutItem _viewLogsItem = CreateMenuItem(Symbol.Document);
+    private readonly MenuFlyoutItem _installUpdateItem = CreateMenuItem(Symbol.Download);
+    private readonly MenuFlyoutItem _checkUpdatesItem = CreateMenuItem(Symbol.Refresh);
+    private readonly MenuFlyoutItem _quitItem = CreateMenuItem(Symbol.Clear);
     private bool _disposed;
 
     internal TrayIconService(MainWindow window, Func<Task> quitAsync)
@@ -41,40 +40,48 @@ internal sealed class TrayIconService : IDisposable
         _window = window;
         _quitAsync = quitAsync;
         _dispatcherQueue = window.DispatcherQueue;
-        _icon = LoadIcon();
 
-        ConfigureMenu();
-        _menu.Opening += Menu_Opening;
-        _notifyIcon.Icon = _icon;
-        _notifyIcon.ContextMenuStrip = _menu;
-        _notifyIcon.MouseDoubleClick += NotifyIcon_MouseDoubleClick;
-        _window.TrayStateChanged += Window_TrayStateChanged;
-        Refresh();
-        _notifyIcon.Visible = true;
+        try
+        {
+            ConfigureMenu();
+            ConfigureTrayIcon();
+            _window.TrayStateChanged += Window_TrayStateChanged;
+            Refresh();
+            _notifyIcon.ForceCreate(enablesEfficiencyMode: false);
+        }
+        catch
+        {
+            Dispose();
+            throw;
+        }
     }
 
     private void ConfigureMenu()
     {
-        _menu.Items.AddRange(
+        MenuFlyoutItemBase[] items =
         [
             _statusItem,
             _detailItem,
-            new Forms.ToolStripSeparator(),
+            new MenuFlyoutSeparator(),
             _showItem,
             _openCodexItem,
             _restartCodexItem,
             _enabledItem,
             _reinjectItem,
-            new Forms.ToolStripSeparator(),
+            new MenuFlyoutSeparator(),
             _managePackagesItem,
             _copySkillItem,
             _viewLogsItem,
-            new Forms.ToolStripSeparator(),
+            new MenuFlyoutSeparator(),
             _installUpdateItem,
             _checkUpdatesItem,
-            new Forms.ToolStripSeparator(),
+            new MenuFlyoutSeparator(),
             _quitItem,
-        ]);
+        ];
+        foreach (var item in items)
+        {
+            _menu.Items.Add(item);
+        }
 
         _showItem.Click += (_, _) => Dispatch(
             _showItem,
@@ -136,23 +143,37 @@ internal sealed class TrayIconService : IDisposable
         _quitItem.Click += (_, _) => Dispatch(_quitItem, _quitAsync);
     }
 
-    private void Menu_Opening(object? sender, CancelEventArgs args)
+    private void ConfigureTrayIcon()
     {
-        Refresh();
+        _showWindowCommand.ExecuteRequested += ShowWindowCommand_ExecuteRequested;
+        _refreshMenuCommand.ExecuteRequested += RefreshMenuCommand_ExecuteRequested;
+
+        _notifyIcon.Icon = LoadIcon();
+        _notifyIcon.ContextMenuMode = ContextMenuMode.SecondWindow;
+        _notifyIcon.ContextFlyout = _menu;
+        _notifyIcon.LeftClickCommand = _showWindowCommand;
+        _notifyIcon.RightClickCommand = _refreshMenuCommand;
+        _notifyIcon.NoLeftClickDelay = true;
     }
 
-    private void NotifyIcon_MouseDoubleClick(object? sender, Forms.MouseEventArgs args)
+    private void ShowWindowCommand_ExecuteRequested(
+        XamlUICommand sender,
+        ExecuteRequestedEventArgs args)
     {
-        if (args.Button == Forms.MouseButtons.Left)
-        {
-            Dispatch(
-                _showItem,
-                () =>
-                {
-                    _window.ShowFromTray();
-                    return Task.CompletedTask;
-                });
-        }
+        Dispatch(
+            _showItem,
+            () =>
+            {
+                _window.ShowFromTray();
+                return Task.CompletedTask;
+            });
+    }
+
+    private void RefreshMenuCommand_ExecuteRequested(
+        XamlUICommand sender,
+        ExecuteRequestedEventArgs args)
+    {
+        Refresh();
     }
 
     private void Window_TrayStateChanged()
@@ -174,43 +195,50 @@ internal sealed class TrayIconService : IDisposable
 
         _statusItem.Text = Limit(statusTitle, 96);
         _detailItem.Text = Limit(statusDetail ?? string.Empty, 120);
-        _detailItem.Visible = !string.IsNullOrWhiteSpace(statusDetail);
+        _detailItem.Visibility = string.IsNullOrWhiteSpace(statusDetail)
+            ? Microsoft.UI.Xaml.Visibility.Collapsed
+            : Microsoft.UI.Xaml.Visibility.Visible;
         _showItem.Text = Text(PresentationTextKey.MenuShow);
+        _showItem.IsEnabled = true;
         _openCodexItem.Text = Text(PresentationTextKey.OverviewOpenCodex);
-        _openCodexItem.Enabled = actions?.OpenCodex == true;
+        _openCodexItem.IsEnabled = actions?.OpenCodex == true;
         _restartCodexItem.Text = Text(PresentationTextKey.OverviewRestartAndConnect);
-        _restartCodexItem.Visible = actions?.RestartCodex == true;
-        _restartCodexItem.Enabled = actions?.RestartCodex == true;
+        _restartCodexItem.Visibility = actions?.RestartCodex == true
+            ? Microsoft.UI.Xaml.Visibility.Visible
+            : Microsoft.UI.Xaml.Visibility.Collapsed;
+        _restartCodexItem.IsEnabled = actions?.RestartCodex == true;
         _enabledItem.Text = Text(PresentationTextKey.OverviewEnable);
-        _enabledItem.Checked = snapshot?.Enabled == true;
-        _enabledItem.Enabled = actions?.SetEnabled == true;
+        _enabledItem.IsChecked = snapshot?.Enabled == true;
+        _enabledItem.IsEnabled = actions?.SetEnabled == true;
         _reinjectItem.Text = Text(PresentationTextKey.OverviewReinject);
-        _reinjectItem.Enabled = actions?.Reinject == true;
+        _reinjectItem.IsEnabled = actions?.Reinject == true;
         _managePackagesItem.Text = Text(PresentationTextKey.OverviewManagePackages);
-        _managePackagesItem.Enabled = actions?.OpenPackagesDirectory == true;
+        _managePackagesItem.IsEnabled = actions?.OpenPackagesDirectory == true;
         _copySkillItem.Text = Text(PresentationTextKey.OverviewCopy);
-        _copySkillItem.Enabled = actions?.ReadAuthoringPrompt == true;
+        _copySkillItem.IsEnabled = actions?.ReadAuthoringPrompt == true;
         _viewLogsItem.Text = Text(PresentationTextKey.OverviewViewLogs);
-        _viewLogsItem.Enabled = actions?.OpenLogFile == true;
+        _viewLogsItem.IsEnabled = actions?.OpenLogFile == true;
 
         var updateVersion = _window.AvailableUpdateVersion;
         _installUpdateItem.Text = Text(
             PresentationTextKey.UpdateInstall,
             ("version", updateVersion ?? string.Empty));
-        _installUpdateItem.Visible = !string.IsNullOrWhiteSpace(updateVersion);
-        _installUpdateItem.Enabled = actions?.InstallAppUpdate == true
+        _installUpdateItem.Visibility = string.IsNullOrWhiteSpace(updateVersion)
+            ? Microsoft.UI.Xaml.Visibility.Collapsed
+            : Microsoft.UI.Xaml.Visibility.Visible;
+        _installUpdateItem.IsEnabled = actions?.InstallAppUpdate == true
             && !_window.CheckingUpdate
             && !_window.ApplyingUpdate;
         _checkUpdatesItem.Text = Text(
             _window.CheckingUpdate
                 ? PresentationTextKey.UpdateChecking
                 : PresentationTextKey.UpdateCheck);
-        _checkUpdatesItem.Enabled = actions?.CheckAppUpdate == true
+        _checkUpdatesItem.IsEnabled = actions?.CheckAppUpdate == true
             && !_window.CheckingUpdate
             && !_window.ApplyingUpdate;
         _quitItem.Text = Text(PresentationTextKey.MenuQuit);
 
-        _notifyIcon.Text = Limit(
+        _notifyIcon.ToolTipText = Limit(
             $"{Text(PresentationTextKey.AppName)} — {statusTitle}",
             MaximumTooltipLength);
     }
@@ -232,7 +260,7 @@ internal sealed class TrayIconService : IDisposable
             ShowNotification(
                 Text(PresentationTextKey.AppName),
                 Text(PresentationTextKey.OverviewCopied),
-                Forms.ToolTipIcon.Info);
+                NotificationIcon.Info);
         }
         else
         {
@@ -240,17 +268,17 @@ internal sealed class TrayIconService : IDisposable
         }
     }
 
-    private void Dispatch(Forms.ToolStripItem source, Func<Task> action)
+    private void Dispatch(MenuFlyoutItemBase source, Func<Task> action)
     {
         if (_disposed)
         {
             return;
         }
 
-        source.Enabled = false;
+        source.IsEnabled = false;
         if (!_dispatcherQueue.TryEnqueue(() => _ = ExecuteAsync(action)))
         {
-            source.Enabled = true;
+            source.IsEnabled = true;
         }
     }
 
@@ -276,21 +304,21 @@ internal sealed class TrayIconService : IDisposable
         ShowNotification(
             Text(PresentationTextKey.StatusErrorTitle),
             message,
-            Forms.ToolTipIcon.Error);
+            NotificationIcon.Error);
     }
 
-    private void ShowNotification(string title, string message, Forms.ToolTipIcon icon)
+    private void ShowNotification(string title, string message, NotificationIcon icon)
     {
         if (_disposed)
         {
             return;
         }
 
-        _notifyIcon.ShowBalloonTip(
-            3000,
+        _notifyIcon.ShowNotification(
             Limit(title, MaximumTooltipLength),
             Limit(message, MaximumBalloonTextLength),
-            icon);
+            icon,
+            timeout: TimeSpan.FromSeconds(3));
     }
 
     private string Text(string key, params (string Name, string Value)[] replacements)
@@ -303,6 +331,15 @@ internal sealed class TrayIconService : IDisposable
         return value.Length <= maximumLength
             ? value
             : string.Concat(value.AsSpan(0, maximumLength - 1), "…");
+    }
+
+    private static MenuFlyoutItem CreateMenuItem(Symbol symbol, bool isEnabled = true)
+    {
+        return new MenuFlyoutItem
+        {
+            Icon = new SymbolIcon(symbol),
+            IsEnabled = isEnabled,
+        };
     }
 
     private static Icon LoadIcon()
@@ -331,12 +368,10 @@ internal sealed class TrayIconService : IDisposable
 
         _disposed = true;
         _window.TrayStateChanged -= Window_TrayStateChanged;
-        _menu.Opening -= Menu_Opening;
-        _notifyIcon.MouseDoubleClick -= NotifyIcon_MouseDoubleClick;
-        _notifyIcon.Visible = false;
-        _notifyIcon.ContextMenuStrip = null;
+        _showWindowCommand.ExecuteRequested -= ShowWindowCommand_ExecuteRequested;
+        _refreshMenuCommand.ExecuteRequested -= RefreshMenuCommand_ExecuteRequested;
+        _notifyIcon.LeftClickCommand = null;
+        _notifyIcon.RightClickCommand = null;
         _notifyIcon.Dispose();
-        _menu.Dispose();
-        _icon.Dispose();
     }
 }


### PR DESCRIPTION
## 变更内容

- 将 Windows 托盘从 Windows Forms NotifyIcon 迁移到 H.NotifyIcon.WinUI
- 使用 WinUI MenuFlyout、图标与 ToggleMenuFlyoutItem 保留状态、连接、包管理、更新和退出操作
- 保留单击显示窗口、右键刷新菜单、通知提示和完整资源释放语义

## 验证

- `dotnet restore windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj -p:EnableWindowsTargeting=true`：通过
- `git diff --cached --check`：通过
- 敏感信息模式检查：无命中
- 完整 Windows x64/ARM64 构建、打包与验证由本 PR 的 Windows CI 执行