### PR TITLE
fix: 修复 Windows 托盘菜单首次打开宽度

### DIFF
--- a/windows/CodexTweaks.Windows/Services/TrayIconService.cs
+++ b/windows/CodexTweaks.Windows/Services/TrayIconService.cs
@@ -1,4 +1,5 @@
 using System.Drawing;
+using System.Runtime.InteropServices;
 using CodexTweaks.Windows.Generated;
 using H.NotifyIcon;
 using H.NotifyIcon.Core;
@@ -12,6 +13,7 @@ internal sealed class TrayIconService : IDisposable
 {
     private const int MaximumTooltipLength = 127;
     private const int MaximumBalloonTextLength = 255;
+    private const double InitialMenuWidthDips = 340.0;
 
     private readonly MainWindow _window;
     private readonly Func<Task> _quitAsync;
@@ -34,6 +36,8 @@ internal sealed class TrayIconService : IDisposable
     private readonly MenuFlyoutItem _installUpdateItem = new();
     private readonly MenuFlyoutItem _checkUpdatesItem = new();
     private readonly MenuFlyoutItem _quitItem = new();
+    private bool _initialMenuWidthPrepared;
+    private bool _initialMenuWidthResetPending;
     private bool _disposed;
 
     internal TrayIconService(MainWindow window, Func<Task> quitAsync)
@@ -175,6 +179,53 @@ internal sealed class TrayIconService : IDisposable
         ExecuteRequestedEventArgs args)
     {
         Refresh();
+        PrepareInitialMenuWidth();
+    }
+
+    private void PrepareInitialMenuWidth()
+    {
+        if (_initialMenuWidthPrepared || _initialMenuWidthResetPending)
+        {
+            return;
+        }
+
+        _initialMenuWidthResetPending = true;
+
+        // H.NotifyIcon 2.3.2 measures SecondWindow flyouts before their XamlRoot
+        // provides a DPI scale on first open. Give that synchronous measurement
+        // a physical-width floor, then restore WinUI's native auto sizing.
+        _statusItem.MinWidth = InitialMenuWidthDips * GetCursorRasterizationScale();
+        if (_dispatcherQueue.TryEnqueue(
+                DispatcherQueuePriority.Low,
+                CompleteInitialMenuWidth))
+        {
+            return;
+        }
+
+        _statusItem.MinWidth = 0;
+        _initialMenuWidthResetPending = false;
+    }
+
+    private void CompleteInitialMenuWidth()
+    {
+        _statusItem.MinWidth = 0;
+        _initialMenuWidthResetPending = false;
+        _initialMenuWidthPrepared = true;
+    }
+
+    private static double GetCursorRasterizationScale()
+    {
+        var dpi = GetDpiForSystem();
+        if (GetCursorPos(out var cursorPosition))
+        {
+            var cursorWindow = WindowFromPoint(cursorPosition);
+            if (cursorWindow != nint.Zero)
+            {
+                dpi = GetDpiForWindow(cursorWindow);
+            }
+        }
+
+        return Math.Max(1.0, dpi / 96.0);
     }
 
     private void Window_TrayStateChanged()
@@ -350,6 +401,18 @@ internal sealed class TrayIconService : IDisposable
 
         return (Icon)SystemIcons.Application.Clone();
     }
+
+    [DllImport("user32.dll")]
+    private static extern bool GetCursorPos(out Point point);
+
+    [DllImport("user32.dll")]
+    private static extern nint WindowFromPoint(Point point);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForWindow(nint windowHandle);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetDpiForSystem();
 
     public void Dispose()
     {


### PR DESCRIPTION
## 变更说明

- 首次打开 Windows 托盘菜单前，根据光标所在显示器 DPI 设置临时最小宽度
- 首次布局完成后恢复 WinUI 原生自动尺寸，避免 H.NotifyIcon 首次测量产生过窄菜单

## 验证

- `mise run test` 已通过
- `mise run verify` 已通过
- `mise run contract:check` 已通过，生成文件无漂移
- WinUI 的 `XamlCompiler.exe` 无法在 macOS 执行；由 PR 的 Windows CI 覆盖 x64/ARM64 编译、打包与验证