### PR TITLE
fix: 升级 Windows 托盘菜单到 .NET 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Verify Go backend on Windows
         shell: pwsh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v6
         with:
-          dotnet-version: 8.0.x
+          dotnet-version: 10.0.x
 
       - name: Test Go backend on Windows
         shell: pwsh

--- a/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
+++ b/windows/CodexTweaks.Windows/CodexTweaks.Windows.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net10.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
     <RootNamespace>CodexTweaks.Windows</RootNamespace>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.3.2" />
+    <PackageReference Include="H.NotifyIcon.WinUI" Version="2.5.0-beta.1" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.4.0" />
     <PackageReference Include="Velopack" Version="1.2.0" />
   </ItemGroup>

--- a/windows/CodexTweaks.Windows/Services/TrayIconService.cs
+++ b/windows/CodexTweaks.Windows/Services/TrayIconService.cs
@@ -1,6 +1,4 @@
 using System.Drawing;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using CodexTweaks.Windows.Generated;
 using H.NotifyIcon;
 using H.NotifyIcon.Core;
@@ -14,12 +12,6 @@ internal sealed class TrayIconService : IDisposable
 {
     private const int MaximumTooltipLength = 127;
     private const int MaximumBalloonTextLength = 255;
-    private const int HideWindowCommand = 0;
-
-    private static readonly PropertyInfo? ContextMenuWindowProperty =
-        typeof(TaskbarIcon).GetProperty(
-            "ContextMenuWindow",
-            BindingFlags.Instance | BindingFlags.NonPublic);
 
     private readonly MainWindow _window;
     private readonly Func<Task> _quitAsync;
@@ -57,7 +49,6 @@ internal sealed class TrayIconService : IDisposable
             _window.TrayStateChanged += Window_TrayStateChanged;
             Refresh();
             _notifyIcon.ForceCreate(enablesEfficiencyMode: false);
-            WarmUpContextMenu();
         }
         catch
         {
@@ -184,31 +175,6 @@ internal sealed class TrayIconService : IDisposable
         ExecuteRequestedEventArgs args)
     {
         Refresh();
-    }
-
-    private void WarmUpContextMenu()
-    {
-        try
-        {
-            // H.NotifyIcon 2.5 preloads its private SecondWindow host before the
-            // first measurement. Backport that behavior while this app remains
-            // on the library's .NET 8-compatible release line.
-            if (ContextMenuWindowProperty?.GetValue(_notifyIcon)
-                is not Microsoft.UI.Xaml.Window contextMenuWindow)
-            {
-                App.Log("Tray context menu warm-up was unavailable.");
-                return;
-            }
-
-            contextMenuWindow.Activate();
-            var windowHandle = WinRT.Interop.WindowNative.GetWindowHandle(contextMenuWindow);
-            _ = ShowWindow(windowHandle, HideWindowCommand);
-            App.Log("Tray context menu warm-up completed.");
-        }
-        catch (Exception exception)
-        {
-            App.Log($"Tray context menu warm-up failed: {exception}");
-        }
     }
 
     private void Window_TrayStateChanged()
@@ -384,9 +350,6 @@ internal sealed class TrayIconService : IDisposable
 
         return (Icon)SystemIcons.Application.Clone();
     }
-
-    [DllImport("user32.dll")]
-    private static extern bool ShowWindow(nint windowHandle, int command);
 
     public void Dispose()
     {


### PR DESCRIPTION
## 变更内容

- 将 Windows 前端目标框架及 CI/Release SDK 升级到 .NET 10。
- 升级 H.NotifyIcon.WinUI 至 2.5.0-beta.1，使用上游已合并的 SecondWindow 首次加载与生命周期修复。
- 删除依赖私有反射并会在启动阶段触发 XamlRoot 异常的菜单预热；保留现有 WinUI 半透明菜单、文本布局和交互。

## 验证

- `mise run verify`
- Windows 11 ARM64 虚拟机：`scripts/build-windows.ps1 -Version 3.1.0-beta.5 -BuildNumber 3`，x64 / ARM64 均构建成功。
- Windows 11 ARM64 虚拟机：`scripts/package-windows.ps1 -Version 3.1.0-beta.5 -Channel beta`，两架构均打包成功。
- Windows 11 ARM64 虚拟机：`scripts/verify-windows.ps1 -Version 3.1.0-beta.5 -Channel beta -RequirePackages`，两架构 PE/资源/包校验通过，ARM64 后端 RPC smoke 通过，精确校验 6 个发布资产；x64 原生执行因 ARM64 宿主跳过。
- 真实运行 ARM64 publish 产物：前端与 Go sidecar 持续响应；第一次右键托盘图标时菜单宽度按内容正确测量、完整显示，无窄条、超宽、滚动条或启动崩溃；日志无 XamlRoot/ShowAt 异常。