### PR TITLE
feat: 支持功能包主机能力

### DIFF
--- a/Skills/develop-codex-tweaks-package/SKILL.md
+++ b/Skills/develop-codex-tweaks-package/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: develop-codex-tweaks-package
-description: Create or modify Codex Tweaks API v2 feature packages, including lifecycle-safe browser injection, npm dependencies, package dependencies, priorities, and Git-installable package metadata. Use when developing a package that runs through Codex Tweaks on macOS or Windows; do not use for changing the package manager itself unless explicitly requested.
+description: Create or modify Codex Tweaks API v2 feature packages for the packaged macOS or Windows app, including lifecycle-safe browser injection, independently versioned host capabilities, dependencies, priorities, and Git-installable metadata.
 ---
 
 # Develop Codex Tweaks Packages
@@ -12,7 +12,8 @@ Build one independently loadable feature package for Codex Tweaks while preservi
 - Use the packages directory shown by Codex Tweaks as the source of truth. Its default location is `~/Library/Application Support/Codex Tweaks/Tweaks/packages/<package>/` on macOS and `%LOCALAPPDATA%\Codex Tweaks\Tweaks\packages\<package>\` on Windows.
 - One direct child directory is one package. The package-level switch controls everything inside it.
 - Inspect the target package and relevant Codex page behavior before editing. If the user asks only for review or diagnosis, remain read-only.
-- Keep changes inside the requested package unless the task explicitly requires modifying Codex Tweaks itself or another package.
+- Treat Codex Tweaks as an already installed, packaged host. Do not search for, modify, rebuild, or replace its source or application bundle; keep all edits inside the requested package.
+- Use only the package API documented here and capabilities returned by the installed app's current `AppSnapshot.availableCapabilities`. If a required operation is not exposed, report that boundary instead of adding a package-local bridge or patching Codex private modules directly.
 - A newly discovered or remotely installed package remains disabled until the user explicitly enables it in the app.
 
 ## Manifest contract
@@ -30,7 +31,8 @@ Each package must contain `package.json` and a source entry inside the package d
     "apiVersion": 2,
     "entry": "src/index.js",
     "priority": 100,
-    "packageDependencies": {}
+    "packageDependencies": {},
+    "capabilities": {}
   }
 }
 ```
@@ -41,6 +43,15 @@ Each package must contain `package.json` and a source entry inside the package d
 - `dependencies` contains npm compile-time dependencies. Use explicit versions and commit `package-lock.json` whenever it is non-empty.
 - `codexTweaks.entry` is resolved inside the package and compiled by esbuild for the browser.
 - `codexTweaks.priority` is the author's default priority; smaller values load earlier. Never rewrite it merely to represent a user's local ordering because the app stores user overrides separately.
+
+## Host capabilities
+
+Before selecting or using a host capability, obtain the latest `AppSnapshot` from the installed Codex Tweaks backend and read `AppSnapshot.availableCapabilities`:
+
+- The `initialize` and `getState` JSON-RPC responses contain the snapshot in `result`; a pushed `state` event contains it in `data`.
+- On an already initialized newline-delimited JSON-RPC connection, send `{"id": <request-id>, "method": "getState"}` and read `result.availableCapabilities`.
+- Treat the returned array as the only authoritative capability catalog. Follow each returned descriptor's manifest declaration, runtime access, usage, constraints, methods, fields, errors, and examples exactly; do not infer capabilities from the app version or hardcode a catalog from this Skill.
+- Keep requests under `codexTweaks.capabilities`. The host validates the manifest and exposes only the approved capability handles through `api.capabilities` / `context.capabilities` at runtime.
 
 ## Package dependencies
 
@@ -112,8 +123,9 @@ The context contains:
 - `id`, `name`, and `version` for the active compiled package.
 - `root`, an isolated DOM root owned by the package.
 - `onCleanup(callback)` and `api.registerCleanup(callback)` for teardown.
-- `api.registerLibrary`, `hasLibrary`, `getLibrary`, and `listLibraries` for capabilities provided by this package.
-- `dependencies.has`, `get`, and `list` for declared dependency capabilities. Access is limited to dependencies named in the manifest.
+- `api.capabilities` / `capabilities` for independently versioned host capabilities declared in the manifest.
+- `api.registerLibrary`, `hasLibrary`, `getLibrary`, and `listLibraries` for libraries exported by this package.
+- `dependencies.has`, `get`, and `list` for declared dependency packages and their exported libraries. Access is limited to dependencies named in the manifest.
 
 Every observer, timer, event listener, DOM node mounted outside `root`, and external state mutation must be reversible. Activation and cleanup must tolerate reinjection, page refreshes, and target elements appearing later. A package failure must not prevent unrelated packages from running.
 

--- a/app/Sources/BackendProtocol.swift
+++ b/app/Sources/BackendProtocol.swift
@@ -69,12 +69,81 @@ struct BackendAppStatus: Codable, Equatable, Sendable {
     let message: String?
 }
 
+struct BackendCapabilityUsageDescriptor: Codable, Equatable, Sendable {
+    let useWhen: [String]
+    let constraints: [String]
+    let manifestExample: String
+    let runtimeExample: String
+}
+
+struct BackendCapabilityManifestDescriptor: Codable, Equatable, Sendable {
+    let requirementJSONPointer: String
+    let fields: [BackendCapabilityFieldDescriptor]
+}
+
+struct BackendCapabilityRuntimeDescriptor: Codable, Equatable, Sendable {
+    let scope: String
+    let requiredAccess: String
+    let optionalAccess: String
+    let properties: [BackendCapabilityFieldDescriptor]
+    let methods: [BackendCapabilityMethodDescriptor]
+}
+
+struct BackendCapabilityMethodDescriptor: Codable, Equatable, Sendable {
+    let name: String
+    let isAsync: Bool
+    let signature: String
+    let description: String
+    let inputs: [BackendCapabilityFieldDescriptor]
+    let outputs: [BackendCapabilityFieldDescriptor]
+    let errors: [BackendCapabilityErrorDescriptor]
+
+    private enum CodingKeys: String, CodingKey {
+        case name
+        case isAsync = "async"
+        case signature, description, inputs, outputs, errors
+    }
+}
+
+struct BackendCapabilityFieldDescriptor: Codable, Equatable, Sendable {
+    let path: String
+    let type: String
+    let itemType: String?
+    let format: String?
+    let required: Bool
+    let description: String
+    let values: [String]?
+    let defaultJSON: String?
+    let minimum: Int?
+    let maximum: Int?
+    let minimumItems: Int?
+    let maximumItems: Int?
+    let minimumLength: Int?
+    let maximumLength: Int?
+}
+
+struct BackendCapabilityErrorDescriptor: Codable, Equatable, Sendable {
+    let code: String
+    let description: String
+}
+
+struct BackendCapabilityDescriptor: Codable, Equatable, Sendable {
+    let descriptorVersion: Int
+    let id: String
+    let version: String
+    let summary: String
+    let usage: BackendCapabilityUsageDescriptor
+    let manifest: BackendCapabilityManifestDescriptor
+    let runtime: BackendCapabilityRuntimeDescriptor
+}
+
 struct BackendAppSnapshot: Codable, Equatable, Sendable {
     let protocolVersion: Int
     let presentation: BackendPresentationContract
     let status: BackendAppStatus
     let enabled: Bool
     let developerMode: Bool
+    let availableCapabilities: [BackendCapabilityDescriptor]
     let packages: [TweakPackage]
     let disabledPackageIDs: [String]
     let buildingPackageIDs: [String]

--- a/app/Tests/BackendProtocolTests.swift
+++ b/app/Tests/BackendProtocolTests.swift
@@ -115,6 +115,42 @@ final class BackendProtocolTests: XCTestCase {
               "status": {"kind": "connected", "targetCount": 1},
               "enabled": true,
               "developerMode": false,
+              "availableCapabilities": [{
+                "descriptorVersion": 1,
+                "id": "network",
+                "version": "1.0.0",
+                "summary": "Host-scoped HTTPS requests.",
+                "usage": {
+                  "useWhen": ["Renderer fetch is unavailable."],
+                  "constraints": ["Only granted public HTTPS origins."],
+                  "manifestExample": "{}",
+                  "runtimeExample": "api.capabilities.require(\\"network\\")"
+                },
+                "manifest": {
+                  "requirementJSONPointer": "/codexTweaks/capabilities/network",
+                  "fields": [{
+                    "path": "version",
+                    "type": "string",
+                    "required": true,
+                    "description": "Independent version requirement."
+                  }]
+                },
+                "runtime": {
+                  "scope": "all-renderers",
+                  "requiredAccess": "api.capabilities.require(\\"network\\")",
+                  "optionalAccess": "api.capabilities.get(\\"network\\")",
+                  "properties": [],
+                  "methods": [{
+                    "name": "request",
+                    "async": true,
+                    "signature": "request(options) => Promise<response>",
+                    "description": "Performs one request.",
+                    "inputs": [],
+                    "outputs": [],
+                    "errors": []
+                  }]
+                }
+              }],
               "packages": [],
               "disabledPackageIDs": [],
               "buildingPackageIDs": [],
@@ -156,6 +192,12 @@ final class BackendProtocolTests: XCTestCase {
         XCTAssertEqual(snapshot.protocolVersion, 3)
         XCTAssertEqual(snapshot.presentation.version, 1)
         XCTAssertEqual(snapshot.status.targetCount, 1)
+        XCTAssertEqual(snapshot.availableCapabilities.first?.id, "network")
+        XCTAssertEqual(snapshot.availableCapabilities.first?.runtime.methods.first?.isAsync, true)
+        XCTAssertEqual(
+            snapshot.availableCapabilities.first?.manifest.requirementJSONPointer,
+            "/codexTweaks/capabilities/network"
+        )
         XCTAssertEqual(snapshot.update.channel, .stable)
     }
 

--- a/backend/internal/core/builder.go
+++ b/backend/internal/core/builder.go
@@ -115,6 +115,7 @@ func (b *Builder) Build(ctx context.Context, pkg Package, installDependencies, a
 	record := PackageBuildRecord{
 		PackageID: pkg.Manifest.Name, PackageVersion: pkg.Manifest.Version,
 		PackageDependencies: packageDependencyVersions(pkg.Manifest.CodexTweaks.PackageDependencies),
+		Capabilities:        cloneCapabilityRequirements(pkg.Manifest.CodexTweaks.Capabilities),
 		SourceFingerprint:   *pkg.SourceFingerprint, DependencyFingerprint: *pkg.DependencyFingerprint,
 		CompilerVersion: CompilerVersion, NodeVersion: node.Version, BuildDirectoryName: buildDirectoryName,
 		HasCSS: isRegularNonSymlink(filepath.Join(finalDirectory, "bundle.css")), BuiltAt: NewCodableTime(time.Now()),

--- a/backend/internal/core/capability.go
+++ b/backend/internal/core/capability.go
@@ -1,0 +1,305 @@
+package core
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+)
+
+const (
+	NetworkCapabilityID                = "network"
+	NetworkCapabilityVersion           = "1.0.0"
+	UISettingsSectionCapabilityID      = "ui.settings-section"
+	UISettingsSectionCapabilityVersion = "1.0.0"
+)
+
+// CapabilityRequirement is a package's independently versioned request for a
+// host capability. Core package API v2 remains unchanged when capabilities are
+// added or upgraded.
+type CapabilityRequirement struct {
+	Version     string          `json:"version"`
+	Optional    bool            `json:"optional,omitempty"`
+	Permissions json.RawMessage `json:"permissions,omitempty"`
+}
+
+// GrantedCapability is the concrete version negotiated by the current host.
+type GrantedCapability struct {
+	Version     string          `json:"version"`
+	Permissions json.RawMessage `json:"permissions,omitempty"`
+}
+
+type CapabilityDescriptor struct {
+	DescriptorVersion int                          `json:"descriptorVersion"`
+	ID                string                       `json:"id"`
+	Version           string                       `json:"version"`
+	Summary           string                       `json:"summary"`
+	Usage             CapabilityUsageDescriptor    `json:"usage"`
+	Manifest          CapabilityManifestDescriptor `json:"manifest"`
+	Runtime           CapabilityRuntimeDescriptor  `json:"runtime"`
+}
+
+type CapabilityUsageDescriptor struct {
+	UseWhen         []string `json:"useWhen"`
+	Constraints     []string `json:"constraints"`
+	ManifestExample string   `json:"manifestExample"`
+	RuntimeExample  string   `json:"runtimeExample"`
+}
+
+type CapabilityManifestDescriptor struct {
+	RequirementJSONPointer string                      `json:"requirementJSONPointer"`
+	Fields                 []CapabilityFieldDescriptor `json:"fields"`
+}
+
+type CapabilityRuntimeDescriptor struct {
+	Scope          string                       `json:"scope"`
+	RequiredAccess string                       `json:"requiredAccess"`
+	OptionalAccess string                       `json:"optionalAccess"`
+	Properties     []CapabilityFieldDescriptor  `json:"properties"`
+	Methods        []CapabilityMethodDescriptor `json:"methods"`
+}
+
+type CapabilityMethodDescriptor struct {
+	Name        string                      `json:"name"`
+	Async       bool                        `json:"async"`
+	Signature   string                      `json:"signature"`
+	Description string                      `json:"description"`
+	Inputs      []CapabilityFieldDescriptor `json:"inputs"`
+	Outputs     []CapabilityFieldDescriptor `json:"outputs"`
+	Errors      []CapabilityErrorDescriptor `json:"errors"`
+}
+
+type CapabilityFieldDescriptor struct {
+	Path          string   `json:"path"`
+	Type          string   `json:"type"`
+	ItemType      string   `json:"itemType,omitempty"`
+	Format        string   `json:"format,omitempty"`
+	Required      bool     `json:"required"`
+	Description   string   `json:"description"`
+	Values        []string `json:"values,omitempty"`
+	DefaultJSON   *string  `json:"defaultJSON,omitempty"`
+	Minimum       *int     `json:"minimum,omitempty"`
+	Maximum       *int     `json:"maximum,omitempty"`
+	MinimumItems  *int     `json:"minimumItems,omitempty"`
+	MaximumItems  *int     `json:"maximumItems,omitempty"`
+	MinimumLength *int     `json:"minimumLength,omitempty"`
+	MaximumLength *int     `json:"maximumLength,omitempty"`
+}
+
+type CapabilityErrorDescriptor struct {
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}
+
+type CapabilityInvocationError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type capabilityDefinition struct {
+	descriptor CapabilityDescriptor
+	normalize  func(json.RawMessage) (json.RawMessage, error)
+}
+
+var capabilityDefinitions = map[string]capabilityDefinition{
+	NetworkCapabilityID: {
+		descriptor: networkCapabilityDescriptor(),
+		normalize:  normalizeNetworkCapabilityPermissions,
+	},
+	UISettingsSectionCapabilityID: {
+		descriptor: uiSettingsSectionCapabilityDescriptor(),
+		normalize:  normalizeUISettingsSectionPermissions,
+	},
+}
+
+func capabilityString(value string) *string { return &value }
+func capabilityInt(value int) *int          { return &value }
+
+func AvailableCapabilities() []CapabilityDescriptor {
+	ids := make([]string, 0, len(capabilityDefinitions))
+	for id := range capabilityDefinitions {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	result := make([]CapabilityDescriptor, 0, len(ids))
+	for _, id := range ids {
+		result = append(result, cloneCapabilityDescriptor(capabilityDefinitions[id].descriptor))
+	}
+	return result
+}
+
+func cloneCapabilityDescriptor(source CapabilityDescriptor) CapabilityDescriptor {
+	result := source
+	result.Usage.UseWhen = append([]string(nil), source.Usage.UseWhen...)
+	result.Usage.Constraints = append([]string(nil), source.Usage.Constraints...)
+	result.Manifest.Fields = cloneCapabilityFields(source.Manifest.Fields)
+	result.Runtime.Properties = cloneCapabilityFields(source.Runtime.Properties)
+	result.Runtime.Methods = make([]CapabilityMethodDescriptor, len(source.Runtime.Methods))
+	for index, method := range source.Runtime.Methods {
+		result.Runtime.Methods[index] = method
+		result.Runtime.Methods[index].Inputs = cloneCapabilityFields(method.Inputs)
+		result.Runtime.Methods[index].Outputs = cloneCapabilityFields(method.Outputs)
+		result.Runtime.Methods[index].Errors = cloneCapabilityErrors(method.Errors)
+	}
+	return result
+}
+
+func cloneCapabilityFields(source []CapabilityFieldDescriptor) []CapabilityFieldDescriptor {
+	result := make([]CapabilityFieldDescriptor, len(source))
+	for index, field := range source {
+		result[index] = field
+		result[index].Values = append([]string(nil), field.Values...)
+		result[index].DefaultJSON = cloneStringPointer(field.DefaultJSON)
+		result[index].Minimum = cloneIntPointer(field.Minimum)
+		result[index].Maximum = cloneIntPointer(field.Maximum)
+		result[index].MinimumItems = cloneIntPointer(field.MinimumItems)
+		result[index].MaximumItems = cloneIntPointer(field.MaximumItems)
+		result[index].MinimumLength = cloneIntPointer(field.MinimumLength)
+		result[index].MaximumLength = cloneIntPointer(field.MaximumLength)
+	}
+	return result
+}
+
+func cloneCapabilityErrors(source []CapabilityErrorDescriptor) []CapabilityErrorDescriptor {
+	if source == nil {
+		return nil
+	}
+	result := make([]CapabilityErrorDescriptor, len(source))
+	copy(result, source)
+	return result
+}
+
+func cloneIntPointer(source *int) *int {
+	if source == nil {
+		return nil
+	}
+	value := *source
+	return &value
+}
+
+func ResolveCapabilityRequirements(
+	requirements map[string]CapabilityRequirement,
+) (map[string]GrantedCapability, error) {
+	grants := map[string]GrantedCapability{}
+	ids := make([]string, 0, len(requirements))
+	for id := range requirements {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		requirement := requirements[id]
+		if strings.TrimSpace(id) == "" {
+			return nil, errors.New("能力标识不能为空")
+		}
+		version, ok := ParseVersionRequirement(requirement.Version)
+		if !ok {
+			return nil, fmt.Errorf("能力 %s 的版本要求无效：%s", id, requirement.Version)
+		}
+		definition, exists := capabilityDefinitions[id]
+		if !exists {
+			if requirement.Optional {
+				continue
+			}
+			return nil, fmt.Errorf("当前 Codex Tweaks 不提供能力 %s", id)
+		}
+		if !version.Contains(definition.descriptor.Version) {
+			if requirement.Optional {
+				continue
+			}
+			return nil, fmt.Errorf(
+				"能力 %s 需要 %s，当前提供 %s",
+				id, requirement.Version, definition.descriptor.Version,
+			)
+		}
+		permissions, err := definition.normalize(requirement.Permissions)
+		if err != nil {
+			return nil, fmt.Errorf("能力 %s 的权限无效：%w", id, err)
+		}
+		grants[id] = GrantedCapability{
+			Version: definition.descriptor.Version, Permissions: permissions,
+		}
+	}
+	return grants, nil
+}
+
+func cloneCapabilityRequirements(
+	source map[string]CapabilityRequirement,
+) map[string]CapabilityRequirement {
+	result := make(map[string]CapabilityRequirement, len(source))
+	for id, requirement := range source {
+		requirement.Permissions = append(json.RawMessage(nil), requirement.Permissions...)
+		result[id] = requirement
+	}
+	return result
+}
+
+func resolvePackageCapabilities(
+	packageID string,
+	requirements map[string]CapabilityRequirement,
+) (map[string]GrantedCapability, error) {
+	grants, err := ResolveCapabilityRequirements(requirements)
+	if err != nil {
+		return nil, err
+	}
+	if grant, ok := grants[UISettingsSectionCapabilityID]; ok {
+		permissions, err := bindUISettingsSectionPermissions(packageID, grant.Permissions)
+		if err != nil {
+			return nil, err
+		}
+		grant.Permissions = permissions
+		grants[UISettingsSectionCapabilityID] = grant
+	}
+	return grants, nil
+}
+
+type CapabilityBroker struct {
+	network *networkCapability
+}
+
+func NewCapabilityBroker() *CapabilityBroker {
+	return &CapabilityBroker{network: newNetworkCapability()}
+}
+
+func (b *CapabilityBroker) Invoke(
+	ctx context.Context,
+	grants map[string]GrantedCapability,
+	capabilityID string,
+	method string,
+	parameters json.RawMessage,
+) (any, *CapabilityInvocationError) {
+	grant, ok := grants[capabilityID]
+	if !ok {
+		return nil, capabilityFailure("permission_denied", "Capability was not granted to this package")
+	}
+	switch capabilityID {
+	case NetworkCapabilityID:
+		return b.network.Invoke(ctx, grant, method, parameters)
+	case UISettingsSectionCapabilityID:
+		return nil, capabilityFailure("unsupported_method", "Settings sections are managed inside the page runtime")
+	default:
+		return nil, capabilityFailure("capability_unavailable", "Capability is not available")
+	}
+}
+
+func capabilityFailure(code, message string) *CapabilityInvocationError {
+	return &CapabilityInvocationError{Code: code, Message: message}
+}
+
+func decodeCapabilityJSON(raw json.RawMessage, target any) error {
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return errors.New("只能包含一个 JSON 值")
+		}
+		return err
+	}
+	return nil
+}

--- a/backend/internal/core/capability_network.go
+++ b/backend/internal/core/capability_network.go
@@ -1,0 +1,409 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/netip"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	networkDefaultTimeout = 10 * time.Second
+	networkMaximumTimeout = 15 * time.Second
+	networkMaximumBody    = 1 << 20
+)
+
+type NetworkCapabilityPermissions struct {
+	Origins []string `json:"origins"`
+	Methods []string `json:"methods,omitempty"`
+}
+
+type NetworkCapabilityRequest struct {
+	URL          string `json:"url"`
+	Method       string `json:"method,omitempty"`
+	ResponseType string `json:"responseType,omitempty"`
+	TimeoutMS    int    `json:"timeoutMs,omitempty"`
+}
+
+type NetworkCapabilityResponse struct {
+	Status      int    `json:"status"`
+	OK          bool   `json:"ok"`
+	FinalURL    string `json:"finalUrl"`
+	ContentType string `json:"contentType,omitempty"`
+	Body        any    `json:"body,omitempty"`
+}
+
+func networkCapabilityDescriptor() CapabilityDescriptor {
+	return CapabilityDescriptor{
+		DescriptorVersion: 1,
+		ID:                NetworkCapabilityID,
+		Version:           NetworkCapabilityVersion,
+		Summary:           "Performs permission-scoped HTTPS requests in the Go host instead of the Codex renderer.",
+		Usage: CapabilityUsageDescriptor{
+			UseWhen: []string{
+				"A package must call an HTTPS API or resolve a redirect that the Codex page CSP may block.",
+				"The request must be constrained to explicit origins and HTTP methods declared before build time.",
+			},
+			Constraints: []string{
+				"Only public HTTPS origins on the default port are allowed; localhost, private, reserved, and link-local addresses are rejected.",
+				"Version 1 supports GET and HEAD, follows at most 8 permitted redirects, caps effective timeout at 15000 ms, and caps response bodies at 1 MiB.",
+				"Do not use renderer fetch, hidden DOM messages, or localStorage queues as a CSP bypass when this capability is available.",
+			},
+			ManifestExample: `{
+  "network": {
+    "version": "^1.0.0",
+    "permissions": {
+      "origins": ["https://api.example.com"],
+      "methods": ["GET"]
+    }
+  }
+}`,
+			RuntimeExample: `const network = api.capabilities.require("network");
+const response = await network.request({
+  url: "https://api.example.com/value",
+  method: "GET",
+  responseType: "json",
+  timeoutMs: 8000
+});`,
+		},
+		Manifest: CapabilityManifestDescriptor{
+			RequirementJSONPointer: "/codexTweaks/capabilities/network",
+			Fields: []CapabilityFieldDescriptor{
+				{
+					Path: "version", Type: "string", Format: "semver-requirement", Required: true,
+					Description: "Version requirement negotiated independently from codexTweaks.apiVersion.",
+				},
+				{
+					Path: "optional", Type: "boolean", Required: false,
+					Description: "When true, an unavailable or incompatible capability is omitted instead of invalidating the package.",
+					DefaultJSON: capabilityString("false"),
+				},
+				{
+					Path: "permissions.origins", Type: "array", ItemType: "string", Format: "https-origin", Required: true,
+					Description:  "Complete public HTTPS origins permitted for requests and redirects; paths, queries, fragments, credentials, and non-default ports are not allowed.",
+					MinimumItems: capabilityInt(1),
+				},
+				{
+					Path: "permissions.methods", Type: "array", ItemType: "string", Format: "http-method", Required: false,
+					Description: "Permitted HTTP methods.", Values: []string{http.MethodGet, http.MethodHead},
+					DefaultJSON: capabilityString(`["GET"]`),
+				},
+			},
+		},
+		Runtime: CapabilityRuntimeDescriptor{
+			Scope:          "all-renderers",
+			RequiredAccess: `api.capabilities.require("network")`,
+			OptionalAccess: `api.capabilities.get("network")`,
+			Properties: []CapabilityFieldDescriptor{
+				{Path: "id", Type: "string", Required: true, Description: "Stable capability ID.", Values: []string{NetworkCapabilityID}},
+				{Path: "version", Type: "string", Format: "semver", Required: true, Description: "Concrete granted version.", Values: []string{NetworkCapabilityVersion}},
+			},
+			Methods: []CapabilityMethodDescriptor{
+				{
+					Name: "request", Async: true,
+					Signature:   "request(options) => Promise<response>",
+					Description: "Performs one authorized HTTPS request and resolves with a normalized response.",
+					Inputs: []CapabilityFieldDescriptor{
+						{Path: "url", Type: "string", Format: "https-url", Required: true, Description: "Complete URL whose origin must be granted."},
+						{Path: "method", Type: "string", Format: "http-method", Required: false, Description: "Granted HTTP method.", Values: []string{http.MethodGet, http.MethodHead}, DefaultJSON: capabilityString(`"GET"`)},
+						{Path: "responseType", Type: "string", Required: false, Description: "How to decode the response body.", Values: []string{"json", "text", "none"}, DefaultJSON: capabilityString(`"text"`)},
+						{Path: "timeoutMs", Type: "integer", Format: "milliseconds", Required: false, Description: "Request timeout; zero uses 10000 ms and values above 15000 ms are capped.", DefaultJSON: capabilityString("10000"), Minimum: capabilityInt(0), Maximum: capabilityInt(15000)},
+					},
+					Outputs: []CapabilityFieldDescriptor{
+						{Path: "status", Type: "integer", Format: "http-status", Required: true, Description: "HTTP response status code."},
+						{Path: "ok", Type: "boolean", Required: true, Description: "True for status codes from 200 through 299."},
+						{Path: "finalUrl", Type: "string", Format: "https-url", Required: true, Description: "Final URL after permitted redirects."},
+						{Path: "contentType", Type: "string", Required: false, Description: "Response Content-Type header when present."},
+						{Path: "body", Type: "any", Format: "json|string|null", Required: false, Description: "Decoded JSON, text, or no value according to responseType and method."},
+					},
+					Errors: []CapabilityErrorDescriptor{
+						{Code: "permission_denied", Description: "The URL origin or HTTP method was not granted."},
+						{Code: "invalid_request", Description: "The request shape, responseType, timeout, or URL is invalid."},
+						{Code: "timeout", Description: "The request or host bridge timed out."},
+						{Code: "network_error", Description: "The request or response body could not be completed."},
+						{Code: "response_too_large", Description: "The response body exceeded 1 MiB."},
+						{Code: "invalid_response", Description: "A JSON response was not valid JSON."},
+						{Code: "busy", Description: "The capability bridge reached its pending-request limit."},
+						{Code: "bridge_unavailable", Description: "The renderer has no active host capability bridge."},
+					},
+				},
+			},
+		},
+	}
+}
+
+type networkCapability struct {
+	transport http.RoundTripper
+	semaphore chan struct{}
+}
+
+func newNetworkCapability() *networkCapability {
+	resolver := net.DefaultResolver
+	dialer := &net.Dialer{Timeout: 5 * time.Second, KeepAlive: 30 * time.Second}
+	transport := &http.Transport{
+		Proxy: nil,
+		DialContext: func(ctx context.Context, network, address string) (net.Conn, error) {
+			return dialPublicAddress(ctx, resolver, dialer, network, address)
+		},
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          16,
+		IdleConnTimeout:       30 * time.Second,
+		TLSHandshakeTimeout:   5 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+	}
+	return &networkCapability{transport: transport, semaphore: make(chan struct{}, 8)}
+}
+
+func normalizeNetworkCapabilityPermissions(raw json.RawMessage) (json.RawMessage, error) {
+	permissions := NetworkCapabilityPermissions{}
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, errors.New("必须声明 origins")
+	}
+	if err := decodeCapabilityJSON(raw, &permissions); err != nil {
+		return nil, err
+	}
+	origins := map[string]bool{}
+	for _, rawOrigin := range permissions.Origins {
+		origin, err := canonicalHTTPSOrigin(rawOrigin)
+		if err != nil {
+			return nil, err
+		}
+		origins[origin] = true
+	}
+	if len(origins) == 0 {
+		return nil, errors.New("必须声明至少一个 HTTPS origin")
+	}
+	methods := map[string]bool{}
+	if len(permissions.Methods) == 0 {
+		methods[http.MethodGet] = true
+	}
+	for _, rawMethod := range permissions.Methods {
+		method := strings.ToUpper(strings.TrimSpace(rawMethod))
+		if method != http.MethodGet && method != http.MethodHead {
+			return nil, fmt.Errorf("network@1.0.0 不支持方法 %s", rawMethod)
+		}
+		methods[method] = true
+	}
+	permissions.Origins = sortedTrueKeys(origins)
+	permissions.Methods = sortedTrueKeys(methods)
+	return json.Marshal(permissions)
+}
+
+func canonicalHTTPSOrigin(raw string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" {
+		return "", fmt.Errorf("origin 必须是完整 HTTPS 地址：%s", raw)
+	}
+	if parsed.User != nil || parsed.RawQuery != "" || parsed.Fragment != "" || (parsed.Path != "" && parsed.Path != "/") {
+		return "", fmt.Errorf("origin 不能包含凭据、路径、查询或片段：%s", raw)
+	}
+	if port := parsed.Port(); port != "" && port != "443" {
+		return "", fmt.Errorf("origin 只允许默认 HTTPS 端口：%s", raw)
+	}
+	hostname := strings.ToLower(strings.TrimSuffix(parsed.Hostname(), "."))
+	if hostname == "localhost" || strings.HasSuffix(hostname, ".localhost") {
+		return "", fmt.Errorf("origin 不能指向本地服务：%s", raw)
+	}
+	if ip := net.ParseIP(hostname); ip != nil && disallowedNetworkIP(ip) {
+		return "", fmt.Errorf("origin 不能指向内网或本地地址：%s", raw)
+	}
+	host := hostname
+	if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	return "https://" + host, nil
+}
+
+func (n *networkCapability) Invoke(
+	ctx context.Context,
+	grant GrantedCapability,
+	method string,
+	parameters json.RawMessage,
+) (any, *CapabilityInvocationError) {
+	if method != "request" {
+		return nil, capabilityFailure("unsupported_method", "Unknown network capability method")
+	}
+	permissions := NetworkCapabilityPermissions{}
+	if err := json.Unmarshal(grant.Permissions, &permissions); err != nil {
+		return nil, capabilityFailure("capability_unavailable", "Network permissions are invalid")
+	}
+	request := NetworkCapabilityRequest{}
+	if err := decodeCapabilityJSON(parameters, &request); err != nil {
+		return nil, capabilityFailure("invalid_request", "Network request is invalid")
+	}
+	request.Method = strings.ToUpper(strings.TrimSpace(request.Method))
+	if request.Method == "" {
+		request.Method = http.MethodGet
+	}
+	if !containsString(permissions.Methods, request.Method) {
+		return nil, capabilityFailure("permission_denied", "HTTP method was not granted")
+	}
+	request.ResponseType = strings.ToLower(strings.TrimSpace(request.ResponseType))
+	if request.ResponseType == "" {
+		request.ResponseType = "text"
+	}
+	if request.ResponseType != "json" && request.ResponseType != "text" && request.ResponseType != "none" {
+		return nil, capabilityFailure("invalid_request", "Unsupported responseType")
+	}
+	if request.TimeoutMS < 0 {
+		return nil, capabilityFailure("invalid_request", "timeoutMs cannot be negative")
+	}
+	if err := validateGrantedNetworkURL(request.URL, permissions); err != nil {
+		return nil, capabilityFailure("permission_denied", err.Error())
+	}
+	timeout := networkDefaultTimeout
+	if request.TimeoutMS > 0 {
+		timeout = time.Duration(request.TimeoutMS) * time.Millisecond
+	}
+	if timeout > networkMaximumTimeout {
+		timeout = networkMaximumTimeout
+	}
+	requestContext, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	select {
+	case n.semaphore <- struct{}{}:
+		defer func() { <-n.semaphore }()
+	case <-requestContext.Done():
+		return nil, capabilityFailure("timeout", "Network request timed out")
+	}
+	httpRequest, err := http.NewRequestWithContext(requestContext, request.Method, request.URL, nil)
+	if err != nil {
+		return nil, capabilityFailure("invalid_request", "Network URL is invalid")
+	}
+	httpRequest.Header.Set("Accept", "application/json, text/plain;q=0.9, */*;q=0.1")
+	httpRequest.Header.Set("User-Agent", "CodexTweaks/1.0")
+	client := &http.Client{
+		Transport: n.transport,
+		CheckRedirect: func(next *http.Request, via []*http.Request) error {
+			if len(via) >= 8 {
+				return errors.New("too many redirects")
+			}
+			return validateGrantedNetworkURL(next.URL.String(), permissions)
+		},
+	}
+	response, err := client.Do(httpRequest)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(requestContext.Err(), context.DeadlineExceeded) {
+			return nil, capabilityFailure("timeout", "Network request timed out")
+		}
+		return nil, capabilityFailure("network_error", "Network request failed")
+	}
+	defer response.Body.Close()
+	result := NetworkCapabilityResponse{
+		Status: response.StatusCode, OK: response.StatusCode >= 200 && response.StatusCode < 300,
+		FinalURL: response.Request.URL.String(), ContentType: response.Header.Get("Content-Type"),
+	}
+	if request.ResponseType == "none" || request.Method == http.MethodHead {
+		return result, nil
+	}
+	body, err := io.ReadAll(io.LimitReader(response.Body, networkMaximumBody+1))
+	if err != nil {
+		return nil, capabilityFailure("network_error", "Network response could not be read")
+	}
+	if len(body) > networkMaximumBody {
+		return nil, capabilityFailure("response_too_large", "Network response exceeded 1 MiB")
+	}
+	if request.ResponseType == "json" {
+		var decoded any
+		if len(body) > 0 {
+			if err := json.Unmarshal(body, &decoded); err != nil {
+				return nil, capabilityFailure("invalid_response", "Network response was not valid JSON")
+			}
+		}
+		result.Body = decoded
+	} else {
+		result.Body = string(body)
+	}
+	return result, nil
+}
+
+func validateGrantedNetworkURL(raw string, permissions NetworkCapabilityPermissions) error {
+	parsed, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") || parsed.Hostname() == "" || parsed.User != nil {
+		return errors.New("Only complete HTTPS URLs are allowed")
+	}
+	origin, err := canonicalHTTPSOrigin((&url.URL{Scheme: parsed.Scheme, Host: parsed.Host}).String())
+	if err != nil || !containsString(permissions.Origins, origin) {
+		return errors.New("URL origin was not granted")
+	}
+	return nil
+}
+
+func dialPublicAddress(
+	ctx context.Context,
+	resolver *net.Resolver,
+	dialer *net.Dialer,
+	network string,
+	address string,
+) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	addresses := []net.IPAddr{}
+	if ip := net.ParseIP(host); ip != nil {
+		addresses = append(addresses, net.IPAddr{IP: ip})
+	} else {
+		addresses, err = resolver.LookupIPAddr(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(addresses) == 0 {
+		return nil, errors.New("hostname did not resolve")
+	}
+	for _, candidate := range addresses {
+		if disallowedNetworkIP(candidate.IP) {
+			return nil, errors.New("private or local network address was rejected")
+		}
+	}
+	sort.SliceStable(addresses, func(i, j int) bool {
+		return addresses[i].IP.To4() != nil && addresses[j].IP.To4() == nil
+	})
+	var lastError error
+	for _, candidate := range addresses {
+		connection, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(candidate.IP.String(), port))
+		if dialErr == nil {
+			return connection, nil
+		}
+		lastError = dialErr
+	}
+	return nil, lastError
+}
+
+func disallowedNetworkIP(ip net.IP) bool {
+	if ip == nil || ip.IsUnspecified() || ip.IsLoopback() || ip.IsPrivate() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsMulticast() {
+		return true
+	}
+	address, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return true
+	}
+	address = address.Unmap()
+	for _, prefix := range networkReservedPrefixes {
+		if prefix.Contains(address) {
+			return true
+		}
+	}
+	return false
+}
+
+var networkReservedPrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("2001:db8::/32"),
+}

--- a/backend/internal/core/capability_test.go
+++ b/backend/internal/core/capability_test.go
@@ -1,0 +1,212 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestAvailableCapabilitiesAreIndependentlyVersioned(t *testing.T) {
+	got := AvailableCapabilities()
+	if len(got) != 2 || got[0].ID != NetworkCapabilityID || got[1].ID != UISettingsSectionCapabilityID {
+		t.Fatalf("available capabilities are not stable and sorted: %#v", got)
+	}
+	for _, descriptor := range got {
+		if descriptor.DescriptorVersion != 1 || descriptor.Version == "" || descriptor.Summary == "" ||
+			len(descriptor.Usage.UseWhen) == 0 || len(descriptor.Usage.Constraints) == 0 ||
+			descriptor.Usage.ManifestExample == "" || descriptor.Usage.RuntimeExample == "" ||
+			descriptor.Manifest.RequirementJSONPointer == "" || len(descriptor.Manifest.Fields) == 0 ||
+			descriptor.Runtime.RequiredAccess == "" || descriptor.Runtime.OptionalAccess == "" ||
+			len(descriptor.Runtime.Methods) == 0 {
+			t.Fatalf("capability descriptor is incomplete: %#v", descriptor)
+		}
+		for _, field := range descriptor.Manifest.Fields {
+			if field.DefaultJSON == nil {
+				continue
+			}
+			var value any
+			if err := json.Unmarshal([]byte(*field.DefaultJSON), &value); err != nil {
+				t.Fatalf("%s field %s has invalid defaultJSON %q: %v", descriptor.ID, field.Path, *field.DefaultJSON, err)
+			}
+		}
+		for _, method := range descriptor.Runtime.Methods {
+			if method.Signature == "" || method.Description == "" || method.Inputs == nil ||
+				method.Outputs == nil || method.Errors == nil {
+				t.Fatalf("%s method descriptor is incomplete: %#v", descriptor.ID, method)
+			}
+		}
+	}
+	if got[0].Version != NetworkCapabilityVersion ||
+		got[0].Manifest.RequirementJSONPointer != "/codexTweaks/capabilities/network" ||
+		got[0].Runtime.Methods[0].Name != "request" {
+		t.Fatalf("network descriptor is inconsistent: %#v", got[0])
+	}
+	if got[1].Version != UISettingsSectionCapabilityVersion ||
+		got[1].Manifest.RequirementJSONPointer != "/codexTweaks/capabilities/ui.settings-section" ||
+		got[1].Runtime.Methods[1].Name != "register" {
+		t.Fatalf("settings descriptor is inconsistent: %#v", got[1])
+	}
+	encoded, err := json.Marshal(got)
+	if err != nil || !strings.Contains(string(encoded), `"manifestExample"`) ||
+		!strings.Contains(string(encoded), `"runtimeExample"`) ||
+		!strings.Contains(string(encoded), `"requiredAccess"`) {
+		t.Fatalf("machine-readable capability catalog is incomplete: %s, %v", encoded, err)
+	}
+
+	got[0].Usage.UseWhen[0] = "mutated"
+	got[0].Manifest.Fields[0].Description = "mutated"
+	got[0].Runtime.Methods[0].Errors[0].Description = "mutated"
+	fresh := AvailableCapabilities()
+	if fresh[0].Usage.UseWhen[0] == "mutated" || fresh[0].Manifest.Fields[0].Description == "mutated" ||
+		fresh[0].Runtime.Methods[0].Errors[0].Description == "mutated" {
+		t.Fatal("available capability descriptors share mutable catalog storage")
+	}
+}
+
+func TestResolveAndBindPackageCapabilities(t *testing.T) {
+	requirements := map[string]CapabilityRequirement{
+		NetworkCapabilityID: {
+			Version: "^1.0.0",
+			Permissions: json.RawMessage(`{
+              "origins":["https://B.example/", "https://a.example"],
+              "methods":["head", "GET", "GET"]
+            }`),
+		},
+		UISettingsSectionCapabilityID: {
+			Version: "1",
+			Permissions: json.RawMessage(`{
+              "sections":[{"id":"wallpaper","title":"随机背景","after":"personalization"}]
+            }`),
+		},
+		"future.optional": {Version: "*", Optional: true},
+	}
+	grants, err := resolvePackageCapabilities("Codex Random Background", requirements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(grants) != 2 {
+		t.Fatalf("grants = %#v", grants)
+	}
+	network := NetworkCapabilityPermissions{}
+	if err := json.Unmarshal(grants[NetworkCapabilityID].Permissions, &network); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(network.Origins, []string{"https://a.example", "https://b.example"}) ||
+		!reflect.DeepEqual(network.Methods, []string{http.MethodGet, http.MethodHead}) {
+		t.Fatalf("normalized network permissions = %#v", network)
+	}
+	settings := UISettingsSectionPermissions{}
+	if err := json.Unmarshal(grants[UISettingsSectionCapabilityID].Permissions, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if len(settings.Sections) != 1 || settings.Sections[0].Group != "personal" ||
+		settings.Sections[0].Icon != "personalization" ||
+		!strings.HasPrefix(settings.Sections[0].Slug, "codex-tweaks-codex-random-background-wallpaper-") {
+		t.Fatalf("bound settings permissions = %#v", settings)
+	}
+}
+
+func TestCapabilityRequirementsRejectUnavailableVersionsAndInvalidPermissions(t *testing.T) {
+	tests := []map[string]CapabilityRequirement{
+		{"unknown": {Version: "1.0.0"}},
+		{NetworkCapabilityID: {Version: "^2.0.0", Permissions: json.RawMessage(`{"origins":["https://example.com"]}`)}},
+		{NetworkCapabilityID: {Version: "1.0.0", Permissions: json.RawMessage(`{"origins":["http://example.com"]}`)}},
+		{NetworkCapabilityID: {Version: "1.0.0", Permissions: json.RawMessage(`{"origins":["https://example.com"]} {}`)}},
+		{UISettingsSectionCapabilityID: {Version: "1.0.0", Permissions: json.RawMessage(`{"sections":[{"id":"bad id","title":"Bad"}]}`)}},
+	}
+	for _, requirements := range tests {
+		if _, err := ResolveCapabilityRequirements(requirements); err == nil {
+			t.Fatalf("expected requirements to fail: %#v", requirements)
+		}
+	}
+}
+
+func TestNetworkCapabilityRejectsReservedAddressesAndInvalidTimeout(t *testing.T) {
+	for _, raw := range []string{
+		"127.0.0.1", "10.0.0.1", "100.64.0.1", "169.254.169.254",
+		"192.0.2.1", "198.18.0.1", "203.0.113.1", "2001:db8::1", "::1",
+	} {
+		if !disallowedNetworkIP(net.ParseIP(raw)) {
+			t.Fatalf("reserved address was allowed: %s", raw)
+		}
+	}
+	for _, raw := range []string{"1.1.1.1", "2606:4700:4700::1111"} {
+		if disallowedNetworkIP(net.ParseIP(raw)) {
+			t.Fatalf("public address was rejected: %s", raw)
+		}
+	}
+
+	permissions, err := normalizeNetworkCapabilityPermissions(
+		json.RawMessage(`{"origins":["https://example.com"]}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	network := &networkCapability{
+		semaphore: make(chan struct{}, 1),
+		transport: capabilityRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			t.Fatal("negative timeout should be rejected before transport")
+			return nil, nil
+		}),
+	}
+	_, invocationError := network.Invoke(
+		context.Background(),
+		GrantedCapability{Version: NetworkCapabilityVersion, Permissions: permissions},
+		"request",
+		json.RawMessage(`{"url":"https://example.com","timeoutMs":-1}`),
+	)
+	if invocationError == nil || invocationError.Code != "invalid_request" {
+		t.Fatalf("negative timeout was not rejected: %#v", invocationError)
+	}
+}
+
+func TestNetworkCapabilityBrokersGrantedHTTPSRequests(t *testing.T) {
+	permissions, err := normalizeNetworkCapabilityPermissions(
+		json.RawMessage(`{"origins":["https://example.com"],"methods":["GET"]}`),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	requestCount := 0
+	network := &networkCapability{
+		semaphore: make(chan struct{}, 1),
+		transport: capabilityRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+			requestCount++
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"image":"https://cdn.example/image.webp"}`)),
+				Request:    request,
+			}, nil
+		}),
+	}
+	grant := GrantedCapability{Version: NetworkCapabilityVersion, Permissions: permissions}
+	result, invocationError := network.Invoke(
+		context.Background(), grant, "request",
+		json.RawMessage(`{"url":"https://example.com/random","responseType":"json","timeoutMs":1000}`),
+	)
+	if invocationError != nil {
+		t.Fatalf("network invocation failed: %#v", invocationError)
+	}
+	response, ok := result.(NetworkCapabilityResponse)
+	if !ok || !response.OK || response.Status != http.StatusOK || requestCount != 1 {
+		t.Fatalf("network response = %#v, requests = %d", result, requestCount)
+	}
+	if _, invocationError := network.Invoke(
+		context.Background(), grant, "request",
+		json.RawMessage(`{"url":"https://ungranted.example/random"}`),
+	); invocationError == nil || invocationError.Code != "permission_denied" || requestCount != 1 {
+		t.Fatalf("ungranted request was not rejected: %#v", invocationError)
+	}
+}
+
+type capabilityRoundTripFunc func(*http.Request) (*http.Response, error)
+
+func (function capabilityRoundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return function(request)
+}

--- a/backend/internal/core/capability_ui_settings.go
+++ b/backend/internal/core/capability_ui_settings.go
@@ -1,0 +1,263 @@
+package core
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	settingsSectionMaximumCount = 8
+	settingsSectionMaximumTitle = 64
+)
+
+var settingsSectionIDPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,47}$`)
+var settingsSectionIconPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,47}$`)
+var settingsSectionPackageSlugPattern = regexp.MustCompile(`[^a-z0-9]+`)
+
+type UISettingsSectionPermissions struct {
+	Sections []UISettingsSectionPermission `json:"sections"`
+}
+
+type UISettingsSectionPermission struct {
+	ID    string `json:"id"`
+	Title string `json:"title"`
+	Group string `json:"group,omitempty"`
+	Icon  string `json:"icon,omitempty"`
+	After string `json:"after,omitempty"`
+	Slug  string `json:"slug,omitempty"`
+}
+
+type RuntimeSettingsSection struct {
+	PackageID string `json:"packageID"`
+	UISettingsSectionPermission
+}
+
+type SettingsAdapterConfiguration struct {
+	AppModuleURL        string                   `json:"appModuleUrl"`
+	VisibilityModuleURL string                   `json:"visibilityModuleUrl"`
+	Sections            []RuntimeSettingsSection `json:"sections"`
+}
+
+func uiSettingsSectionCapabilityDescriptor() CapabilityDescriptor {
+	return CapabilityDescriptor{
+		DescriptorVersion: 1,
+		ID:                UISettingsSectionCapabilityID,
+		Version:           UISettingsSectionCapabilityVersion,
+		Summary:           "Registers package-owned content as a real Codex settings navigation item and route through the host's private-module adapter.",
+		Usage: CapabilityUsageDescriptor{
+			UseWhen: []string{
+				"A package needs an independently navigable settings page inside Codex settings.",
+				"The package should provide only its page content while the host owns private settings registry, grouping, icon, route, and navigation integration.",
+			},
+			Constraints: []string{
+				"The capability is available only in the main Codex renderer and may be omitted when the current Codex private modules cannot be adapted.",
+				"Declare it as optional when the package has useful behavior in other renderers or can run without a settings page.",
+				"Do not clone native navigation rows, overlay native settings, intercept native clicks, or import and patch Codex private modules from package code.",
+				"mount may run again after route remounting and must return idempotent cleanup for every owned DOM node and side effect.",
+			},
+			ManifestExample: `{
+  "ui.settings-section": {
+    "version": "^1.0.0",
+    "optional": true,
+    "permissions": {
+      "sections": [{
+        "id": "appearance-extra",
+        "title": "扩展外观",
+        "group": "personal",
+        "icon": "personalization",
+        "after": "personalization"
+      }]
+    }
+  }
+}`,
+			RuntimeExample: `const settings = api.capabilities.get("ui.settings-section");
+settings?.register({
+  id: "appearance-extra",
+  mount(container) {
+    const page = document.createElement("div");
+    container.append(page);
+    return () => page.remove();
+  }
+});`,
+		},
+		Manifest: CapabilityManifestDescriptor{
+			RequirementJSONPointer: "/codexTweaks/capabilities/ui.settings-section",
+			Fields: []CapabilityFieldDescriptor{
+				{
+					Path: "version", Type: "string", Format: "semver-requirement", Required: true,
+					Description: "Version requirement negotiated independently from codexTweaks.apiVersion.",
+				},
+				{
+					Path: "optional", Type: "boolean", Required: false,
+					Description: "When true, the package remains valid when the capability or current-renderer adapter is unavailable.",
+					DefaultJSON: capabilityString("false"),
+				},
+				{
+					Path: "permissions.sections", Type: "array", ItemType: "object", Required: true,
+					Description:  "Settings sections the package is allowed to register.",
+					MinimumItems: capabilityInt(1), MaximumItems: capabilityInt(settingsSectionMaximumCount),
+				},
+				{
+					Path: "permissions.sections[].id", Type: "string", Format: "lowercase-kebab-id", Required: true,
+					Description:   "Package-local stable section ID; 1 to 48 characters and unique inside the capability declaration.",
+					MinimumLength: capabilityInt(1), MaximumLength: capabilityInt(48),
+				},
+				{
+					Path: "permissions.sections[].title", Type: "string", Required: true,
+					Description: "Navigation and accessible label.", MinimumLength: capabilityInt(1), MaximumLength: capabilityInt(settingsSectionMaximumTitle),
+				},
+				{
+					Path: "permissions.sections[].group", Type: "string", Required: false,
+					Description: "Native settings group used for placement.",
+					Values:      []string{"personal", "integrations", "coding", "archived"}, DefaultJSON: capabilityString(`"personal"`),
+				},
+				{
+					Path: "permissions.sections[].icon", Type: "string", Format: "settings-icon-key", Required: false,
+					Description: "Existing Codex settings icon key; unavailable keys fall back to personalization.", DefaultJSON: capabilityString(`"personalization"`),
+				},
+				{
+					Path: "permissions.sections[].after", Type: "string", Format: "settings-section-slug", Required: false,
+					Description: "Existing section slug after which this item is inserted inside its group.",
+				},
+			},
+		},
+		Runtime: CapabilityRuntimeDescriptor{
+			Scope:          "main-renderer",
+			RequiredAccess: `api.capabilities.require("ui.settings-section")`,
+			OptionalAccess: `api.capabilities.get("ui.settings-section")`,
+			Properties: []CapabilityFieldDescriptor{
+				{Path: "id", Type: "string", Required: true, Description: "Stable capability ID.", Values: []string{UISettingsSectionCapabilityID}},
+				{Path: "version", Type: "string", Format: "semver", Required: true, Description: "Concrete granted version.", Values: []string{UISettingsSectionCapabilityVersion}},
+			},
+			Methods: []CapabilityMethodDescriptor{
+				{
+					Name: "list", Async: false,
+					Signature:   "list() => section[]",
+					Description: "Returns the settings sections declared and granted to this package.",
+					Inputs:      []CapabilityFieldDescriptor{},
+					Outputs: []CapabilityFieldDescriptor{
+						{Path: "return", Type: "array", ItemType: "object", Required: true, Description: "Granted section descriptors."},
+						{Path: "return[].id", Type: "string", Required: true, Description: "Package-local declared section ID."},
+						{Path: "return[].title", Type: "string", Required: true, Description: "Declared section title."},
+						{Path: "return[].slug", Type: "string", Format: "host-settings-route-slug", Required: true, Description: "Host-generated globally unique route slug."},
+					},
+					Errors: []CapabilityErrorDescriptor{},
+				},
+				{
+					Name: "register", Async: false,
+					Signature:   "register(options) => registration",
+					Description: "Registers the mount callback for one declared section and returns its navigation lifecycle handle.",
+					Inputs: []CapabilityFieldDescriptor{
+						{Path: "id", Type: "string", Required: true, Description: "One section ID declared in manifest permissions."},
+						{Path: "mount", Type: "function", Format: "(container: Element) => void | (() => void)", Required: true, Description: "Mount package-owned content into the supplied route container and optionally return cleanup."},
+					},
+					Outputs: []CapabilityFieldDescriptor{
+						{Path: "id", Type: "string", Required: true, Description: "Registered package-local section ID."},
+						{Path: "slug", Type: "string", Format: "host-settings-route-slug", Required: true, Description: "Host-generated route slug."},
+						{Path: "open", Type: "function", Format: "() => void", Required: true, Description: "Navigates through the real Codex settings router."},
+						{Path: "unregister", Type: "function", Format: "() => void", Required: true, Description: "Removes the section registration; the host also invokes it during package cleanup."},
+					},
+					Errors: []CapabilityErrorDescriptor{
+						{Code: "TypeError", Description: "Options or mount are not valid."},
+						{Code: "Error", Description: "The section was undeclared, already registered, or the private settings adapter is unavailable."},
+					},
+				},
+			},
+		},
+	}
+}
+
+func normalizeUISettingsSectionPermissions(raw json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return nil, errors.New("必须声明 sections")
+	}
+	permissions := UISettingsSectionPermissions{}
+	if err := decodeCapabilityJSON(raw, &permissions); err != nil {
+		return nil, err
+	}
+	if len(permissions.Sections) == 0 || len(permissions.Sections) > settingsSectionMaximumCount {
+		return nil, fmt.Errorf("sections 数量必须为 1 到 %d", settingsSectionMaximumCount)
+	}
+	seen := map[string]bool{}
+	for index := range permissions.Sections {
+		section := &permissions.Sections[index]
+		section.ID = strings.TrimSpace(section.ID)
+		section.Title = strings.TrimSpace(section.Title)
+		section.Group = strings.TrimSpace(section.Group)
+		section.Icon = strings.TrimSpace(section.Icon)
+		section.After = strings.TrimSpace(section.After)
+		section.Slug = ""
+		if !settingsSectionIDPattern.MatchString(section.ID) || seen[section.ID] {
+			return nil, fmt.Errorf("section id 无效或重复：%s", section.ID)
+		}
+		seen[section.ID] = true
+		if section.Title == "" || utf8.RuneCountInString(section.Title) > settingsSectionMaximumTitle {
+			return nil, fmt.Errorf("section %s 的 title 必须为 1 到 %d 个字符", section.ID, settingsSectionMaximumTitle)
+		}
+		if section.Group == "" {
+			section.Group = "personal"
+		}
+		switch section.Group {
+		case "personal", "integrations", "coding", "archived":
+		default:
+			return nil, fmt.Errorf("section %s 的 group 无效", section.ID)
+		}
+		if section.Icon == "" {
+			section.Icon = "personalization"
+		}
+		if !settingsSectionIconPattern.MatchString(section.Icon) {
+			return nil, fmt.Errorf("section %s 的 icon 无效", section.ID)
+		}
+		if section.After != "" && !settingsSectionIconPattern.MatchString(section.After) {
+			return nil, fmt.Errorf("section %s 的 after 无效", section.ID)
+		}
+	}
+	return json.Marshal(permissions)
+}
+
+func bindUISettingsSectionPermissions(packageID string, raw json.RawMessage) (json.RawMessage, error) {
+	permissions := UISettingsSectionPermissions{}
+	if err := json.Unmarshal(raw, &permissions); err != nil {
+		return nil, err
+	}
+	packageSlug := strings.Trim(
+		settingsSectionPackageSlugPattern.ReplaceAllString(strings.ToLower(packageID), "-"),
+		"-",
+	)
+	if packageSlug == "" {
+		packageSlug = "package"
+	}
+	if len(packageSlug) > 32 {
+		packageSlug = strings.Trim(packageSlug[:32], "-")
+	}
+	suffix := FingerprintString(packageID)
+	for index := range permissions.Sections {
+		permissions.Sections[index].Slug = fmt.Sprintf(
+			"codex-tweaks-%s-%s-%s", packageSlug, permissions.Sections[index].ID, suffix[:8],
+		)
+	}
+	return json.Marshal(permissions)
+}
+
+func payloadSettingsSections(payload Payload) []RuntimeSettingsSection {
+	result := []RuntimeSettingsSection{}
+	for _, pkg := range payload.Packages {
+		grant, ok := pkg.Capabilities[UISettingsSectionCapabilityID]
+		if !ok {
+			continue
+		}
+		permissions := UISettingsSectionPermissions{}
+		if json.Unmarshal(grant.Permissions, &permissions) == nil {
+			for _, section := range permissions.Sections {
+				result = append(result, RuntimeSettingsSection{
+					PackageID: pkg.ID, UISettingsSectionPermission: section,
+				})
+			}
+		}
+	}
+	return result
+}

--- a/backend/internal/core/cdp.go
+++ b/backend/internal/core/cdp.go
@@ -63,6 +63,8 @@ type CDPService struct {
 	logger        *Logger
 	mu            sync.Mutex
 	nextCommandID int
+	broker        *CapabilityBroker
+	sessions      map[string]*capabilitySession
 }
 
 func NewCDPService(logger *Logger) *CDPService {
@@ -71,6 +73,7 @@ func NewCDPService(logger *Logger) *CDPService {
 		httpClient: &http.Client{Timeout: 5 * time.Second},
 		dialer:     &websocket.Dialer{HandshakeTimeout: 5 * time.Second, Proxy: http.ProxyFromEnvironment},
 		logger:     logger, nextCommandID: 1,
+		broker: NewCapabilityBroker(), sessions: map[string]*capabilitySession{},
 	}
 }
 
@@ -79,11 +82,18 @@ func (s *CDPService) Inject(ctx context.Context, payload Payload, forceGeneratio
 	defer s.mu.Unlock()
 	targets, err := s.discoverTargets(ctx)
 	if err != nil {
+		s.closeAllCapabilitySessionsLocked()
 		return CDPInjectionResult{}, err
 	}
-	script := InjectionScript(payload, forceGeneration)
+	s.reconcileCapabilitySessionsLocked(targets)
 	result := CDPInjectionResult{TargetCount: len(targets), PackageErrors: map[string]string{}}
 	for _, target := range targets {
+		bridgeSessionID, capabilityTokens, settingsAdapter, err := s.capabilityBridgeForTargetLocked(ctx, target, payload)
+		if err != nil {
+			s.logError(fmt.Sprintf("目标 %s 无法建立能力通道：%v", target.ID, err))
+			continue
+		}
+		script := injectionScriptWithCapabilities(payload, forceGeneration, bridgeSessionID, capabilityTokens, settingsAdapter)
 		value, err := s.evaluate(ctx, script, *target.WebSocketDebuggerURL)
 		if err != nil {
 			s.logError(fmt.Sprintf("目标 %s 注入失败：%v", target.ID, err))
@@ -106,6 +116,7 @@ func (s *CDPService) Inject(ctx context.Context, payload Payload, forceGeneratio
 func (s *CDPService) CleanupAllTargets(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	defer s.closeAllCapabilitySessionsLocked()
 	targets, err := s.discoverTargets(ctx)
 	if err != nil {
 		return err

--- a/backend/internal/core/cdp_capability.go
+++ b/backend/internal/core/cdp_capability.go
@@ -1,0 +1,442 @@
+package core
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	capabilityBindingName       = "__codexTweaksHostCapability"
+	capabilityBridgeVersion     = 1
+	capabilityMaximumPayload    = 64 << 10
+	capabilityMaximumConcurrent = 32
+	capabilityMaximumResponses  = 8
+)
+
+var errCapabilitySessionClosed = errors.New("CDP capability session closed")
+
+type cdpCapabilityEnvelope struct {
+	ID     *int             `json:"id,omitempty"`
+	Method string           `json:"method,omitempty"`
+	Params json.RawMessage  `json:"params,omitempty"`
+	Result json.RawMessage  `json:"result,omitempty"`
+	Error  *cdpCommandError `json:"error,omitempty"`
+}
+
+type cdpCommandError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+type cdpCallResult struct {
+	result json.RawMessage
+	err    error
+}
+
+type capabilityBindingEvent struct {
+	Name               string `json:"name"`
+	Payload            string `json:"payload"`
+	ExecutionContextID int    `json:"executionContextId"`
+}
+
+type cdpScriptParsedEvent struct {
+	ScriptID string `json:"scriptId"`
+	URL      string `json:"url"`
+}
+
+type capabilityBridgeRequest struct {
+	Version    int             `json:"v"`
+	ID         string          `json:"id"`
+	Token      string          `json:"token"`
+	Capability string          `json:"capability"`
+	Method     string          `json:"method"`
+	Parameters json.RawMessage `json:"parameters"`
+}
+
+type capabilityBridgeResponse struct {
+	ID     string                     `json:"id"`
+	OK     bool                       `json:"ok"`
+	Result any                        `json:"result,omitempty"`
+	Error  *CapabilityInvocationError `json:"error,omitempty"`
+}
+
+type capabilityAuthorization struct {
+	packageID string
+	grants    map[string]GrantedCapability
+}
+
+type capabilitySession struct {
+	id          string
+	debuggerURL string
+	connection  *websocket.Conn
+	broker      *CapabilityBroker
+	logger      *Logger
+	secret      string
+
+	writeMu sync.Mutex
+	stateMu sync.Mutex
+	nextID  int
+	pending map[int]chan cdpCallResult
+	done    chan struct{}
+	closed  bool
+
+	authorizationMu sync.RWMutex
+	authorizations  map[string]capabilityAuthorization
+	requestSlots    chan struct{}
+	responseSlots   chan struct{}
+	closeOnce       sync.Once
+
+	scriptMu              sync.RWMutex
+	scripts               map[string]string
+	debuggerEnabled       bool
+	settingsScriptID      string
+	settingsAppModuleURL  string
+	settingsVisibilityURL string
+	adapterMu             sync.Mutex
+}
+
+func openCapabilitySession(
+	ctx context.Context,
+	dialer *websocket.Dialer,
+	allowedOrigin string,
+	target CDPTarget,
+	broker *CapabilityBroker,
+	logger *Logger,
+) (*capabilitySession, error) {
+	header := http.Header{}
+	header.Set("Origin", allowedOrigin)
+	connection, _, err := dialer.DialContext(ctx, *target.WebSocketDebuggerURL, header)
+	if err != nil {
+		return nil, err
+	}
+	id, err := randomHex(12)
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	secret, err := randomHex(32)
+	if err != nil {
+		_ = connection.Close()
+		return nil, err
+	}
+	session := &capabilitySession{
+		id: id, debuggerURL: *target.WebSocketDebuggerURL, connection: connection,
+		broker: broker, logger: logger, secret: secret, nextID: 1,
+		pending: map[int]chan cdpCallResult{}, done: make(chan struct{}),
+		authorizations: map[string]capabilityAuthorization{},
+		requestSlots:   make(chan struct{}, capabilityMaximumConcurrent),
+		responseSlots:  make(chan struct{}, capabilityMaximumResponses),
+		scripts:        map[string]string{},
+	}
+	go session.readLoop()
+	setupContext, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if _, err := session.call(setupContext, "Runtime.enable", map[string]any{}); err != nil {
+		session.Close()
+		return nil, err
+	}
+	if _, err := session.call(setupContext, "Runtime.addBinding", map[string]any{"name": capabilityBindingName}); err != nil {
+		session.Close()
+		return nil, err
+	}
+	return session, nil
+}
+
+func (s *capabilitySession) Closed() bool {
+	select {
+	case <-s.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *capabilitySession) Close() {
+	s.fail(errCapabilitySessionClosed)
+}
+
+func (s *capabilitySession) fail(sessionError error) {
+	s.closeOnce.Do(func() {
+		s.stateMu.Lock()
+		s.closed = true
+		pending := s.pending
+		s.pending = map[int]chan cdpCallResult{}
+		s.stateMu.Unlock()
+		for _, waiter := range pending {
+			waiter <- cdpCallResult{err: sessionError}
+		}
+		close(s.done)
+		_ = s.connection.Close()
+	})
+}
+
+func (s *capabilitySession) call(ctx context.Context, method string, parameters any) (json.RawMessage, error) {
+	s.stateMu.Lock()
+	if s.closed {
+		s.stateMu.Unlock()
+		return nil, errCapabilitySessionClosed
+	}
+	commandID := s.nextID
+	s.nextID++
+	waiter := make(chan cdpCallResult, 1)
+	s.pending[commandID] = waiter
+	s.stateMu.Unlock()
+
+	command := map[string]any{"id": commandID, "method": method, "params": parameters}
+	s.writeMu.Lock()
+	_ = s.connection.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	err := s.connection.WriteJSON(command)
+	s.writeMu.Unlock()
+	if err != nil {
+		s.removePending(commandID)
+		s.fail(err)
+		return nil, err
+	}
+
+	select {
+	case response := <-waiter:
+		return response.result, response.err
+	case <-ctx.Done():
+		s.removePending(commandID)
+		return nil, ctx.Err()
+	case <-s.done:
+		s.removePending(commandID)
+		return nil, errCapabilitySessionClosed
+	}
+}
+
+func (s *capabilitySession) removePending(commandID int) {
+	s.stateMu.Lock()
+	delete(s.pending, commandID)
+	s.stateMu.Unlock()
+}
+
+func (s *capabilitySession) readLoop() {
+	for {
+		_, message, err := s.connection.ReadMessage()
+		if err != nil {
+			s.fail(err)
+			return
+		}
+		envelope := cdpCapabilityEnvelope{}
+		if err := json.Unmarshal(message, &envelope); err != nil {
+			continue
+		}
+		if envelope.ID != nil {
+			s.stateMu.Lock()
+			waiter := s.pending[*envelope.ID]
+			delete(s.pending, *envelope.ID)
+			s.stateMu.Unlock()
+			if waiter != nil {
+				if envelope.Error != nil {
+					waiter <- cdpCallResult{err: fmt.Errorf("CDP 拒绝执行：%s", envelope.Error.Message)}
+				} else {
+					waiter <- cdpCallResult{result: envelope.Result}
+				}
+			}
+			continue
+		}
+		if envelope.Method == "Runtime.bindingCalled" {
+			s.dispatchBindingEvent(envelope.Params)
+		} else if envelope.Method == "Debugger.scriptParsed" {
+			event := cdpScriptParsedEvent{}
+			if json.Unmarshal(envelope.Params, &event) == nil && event.ScriptID != "" && event.URL != "" {
+				s.scriptMu.Lock()
+				s.scripts[event.URL] = event.ScriptID
+				s.scriptMu.Unlock()
+			}
+		}
+	}
+}
+
+func (s *capabilitySession) authorize(payload Payload) map[string]string {
+	authorizations := map[string]capabilityAuthorization{}
+	tokens := map[string]string{}
+	for _, pkg := range payload.Packages {
+		if len(pkg.Capabilities) == 0 {
+			continue
+		}
+		capabilities, _ := json.Marshal(pkg.Capabilities)
+		mac := hmac.New(sha256.New, []byte(s.secret))
+		_, _ = mac.Write([]byte(strings.Join([]string{payload.Version, pkg.ID, string(capabilities)}, "\x00")))
+		token := hex.EncodeToString(mac.Sum(nil))
+		tokens[pkg.ID] = token
+		authorizations[token] = capabilityAuthorization{
+			packageID: pkg.ID,
+			grants:    cloneGrantedCapabilities(pkg.Capabilities),
+		}
+	}
+	s.authorizationMu.Lock()
+	s.authorizations = authorizations
+	s.authorizationMu.Unlock()
+	return tokens
+}
+
+func cloneGrantedCapabilities(source map[string]GrantedCapability) map[string]GrantedCapability {
+	result := make(map[string]GrantedCapability, len(source))
+	for id, grant := range source {
+		grant.Permissions = append(json.RawMessage(nil), grant.Permissions...)
+		result[id] = grant
+	}
+	return result
+}
+
+func (s *capabilitySession) dispatchBindingEvent(raw json.RawMessage) {
+	event := capabilityBindingEvent{}
+	if err := json.Unmarshal(raw, &event); err != nil || event.Name != capabilityBindingName || event.ExecutionContextID <= 0 {
+		return
+	}
+	if len(event.Payload) == 0 || len(event.Payload) > capabilityMaximumPayload {
+		return
+	}
+	request := capabilityBridgeRequest{}
+	if err := json.Unmarshal([]byte(event.Payload), &request); err != nil {
+		return
+	}
+	select {
+	case s.requestSlots <- struct{}{}:
+		go func() {
+			defer func() { <-s.requestSlots }()
+			s.handleCapabilityRequest(event.ExecutionContextID, request)
+		}()
+	default:
+		select {
+		case s.responseSlots <- struct{}{}:
+			go func() {
+				defer func() { <-s.responseSlots }()
+				s.sendCapabilityResponse(event.ExecutionContextID, capabilityBridgeResponse{
+					ID: request.ID, OK: false,
+					Error: capabilityFailure("busy", "Capability bridge is busy"),
+				})
+			}()
+		default:
+		}
+	}
+}
+
+func (s *capabilitySession) handleCapabilityRequest(executionContextID int, request capabilityBridgeRequest) {
+	if request.Version != capabilityBridgeVersion || request.ID == "" || len(request.ID) > 200 ||
+		request.Token == "" || request.Capability == "" || request.Method == "" {
+		s.sendCapabilityResponse(executionContextID, capabilityBridgeResponse{
+			ID: request.ID, OK: false,
+			Error: capabilityFailure("invalid_request", "Capability request is invalid"),
+		})
+		return
+	}
+	s.authorizationMu.RLock()
+	authorization, allowed := s.authorizations[request.Token]
+	s.authorizationMu.RUnlock()
+	if !allowed {
+		s.sendCapabilityResponse(executionContextID, capabilityBridgeResponse{
+			ID: request.ID, OK: false,
+			Error: capabilityFailure("permission_denied", "Capability token is invalid"),
+		})
+		return
+	}
+	requestContext, cancel := context.WithTimeout(context.Background(), networkMaximumTimeout+time.Second)
+	defer cancel()
+	result, invocationError := s.broker.Invoke(
+		requestContext, authorization.grants, request.Capability, request.Method, request.Parameters,
+	)
+	response := capabilityBridgeResponse{ID: request.ID, OK: invocationError == nil, Result: result, Error: invocationError}
+	s.sendCapabilityResponse(executionContextID, response)
+}
+
+func (s *capabilitySession) sendCapabilityResponse(executionContextID int, response capabilityBridgeResponse) {
+	expression := fmt.Sprintf(`(() => {
+  try {
+    return globalThis["__CODEX_TWEAKS__"]?.settleCapability(%s) ?? false;
+  } catch (_) {
+    return false;
+  }
+})()`, JSONLiteral(response))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := s.call(ctx, "Runtime.evaluate", map[string]any{
+		"expression": expression, "contextId": executionContextID,
+		"returnByValue": true, "awaitPromise": false, "userGesture": false,
+	}); err != nil && !errors.Is(err, errCapabilitySessionClosed) && !errors.Is(err, context.Canceled) {
+		if s.logger != nil {
+			s.logger.Error("能力调用结果无法返回 Codex 页面：" + err.Error())
+		}
+	}
+}
+
+func payloadUsesCapabilities(payload Payload) bool {
+	for _, pkg := range payload.Packages {
+		if len(pkg.Capabilities) > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *CDPService) capabilityBridgeForTargetLocked(
+	ctx context.Context,
+	target CDPTarget,
+	payload Payload,
+) (string, map[string]string, *SettingsAdapterConfiguration, error) {
+	if !payloadUsesCapabilities(payload) {
+		if existing := s.sessions[target.ID]; existing != nil {
+			existing.Close()
+			delete(s.sessions, target.ID)
+		}
+		return "", map[string]string{}, nil, nil
+	}
+	existing := s.sessions[target.ID]
+	if existing != nil && (existing.Closed() || existing.debuggerURL != *target.WebSocketDebuggerURL) {
+		existing.Close()
+		delete(s.sessions, target.ID)
+		existing = nil
+	}
+	if existing == nil {
+		created, err := openCapabilitySession(ctx, s.dialer, s.AllowedOrigin, target, s.broker, s.logger)
+		if err != nil {
+			return "", nil, nil, err
+		}
+		s.sessions[target.ID] = created
+		existing = created
+	}
+	adapterContext, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	settingsAdapter, err := existing.ensureSettingsAdapter(adapterContext, payload)
+	if err != nil {
+		if s.logger != nil {
+			s.logger.Error("ui.settings-section@1.0.0 无法适配当前 Codex：" + err.Error())
+		}
+		settingsAdapter = nil
+	}
+	return existing.id, existing.authorize(payload), settingsAdapter, nil
+}
+
+func (s *CDPService) reconcileCapabilitySessionsLocked(targets []CDPTarget) {
+	current := map[string]string{}
+	for _, target := range targets {
+		current[target.ID] = *target.WebSocketDebuggerURL
+	}
+	for targetID, session := range s.sessions {
+		debuggerURL, present := current[targetID]
+		if !present || debuggerURL != session.debuggerURL || session.Closed() {
+			session.Close()
+			delete(s.sessions, targetID)
+		}
+	}
+}
+
+func (s *CDPService) closeAllCapabilitySessionsLocked() {
+	for targetID, session := range s.sessions {
+		session.Close()
+		delete(s.sessions, targetID)
+	}
+}

--- a/backend/internal/core/cdp_settings.go
+++ b/backend/internal/core/cdp_settings.go
@@ -1,0 +1,184 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"regexp"
+	"time"
+)
+
+var appInitialScriptPattern = regexp.MustCompile(`/app-initial-[A-Za-z0-9_-]+\.js(?:\?.*)?$`)
+var settingsPageImportPattern = regexp.MustCompile("import\\(`(\\./settings-page-[A-Za-z0-9_-]+\\.js)`\\)")
+var visibilityAssetPattern = regexp.MustCompile(`\./use-visible-settings-sections-[A-Za-z0-9_-]+\.js`)
+
+func (s *capabilitySession) ensureSettingsAdapter(
+	ctx context.Context,
+	payload Payload,
+) (*SettingsAdapterConfiguration, error) {
+	sections := payloadSettingsSections(payload)
+	if len(sections) == 0 {
+		return nil, nil
+	}
+	s.adapterMu.Lock()
+	defer s.adapterMu.Unlock()
+	if !s.debuggerEnabled {
+		if _, err := s.call(ctx, "Debugger.enable", map[string]any{}); err != nil {
+			return nil, fmt.Errorf("无法启用 Codex 模块适配：%w", err)
+		}
+		s.debuggerEnabled = true
+	}
+	appModuleURL, appScriptID := s.waitForMatchingScript(ctx, appInitialScriptPattern)
+	if appScriptID == "" {
+		return nil, errors.New("当前 Codex 构建中未找到 app-initial 模块")
+	}
+	appSource, err := s.getScriptSource(ctx, appScriptID)
+	if err != nil {
+		return nil, err
+	}
+	settingsAsset := matchAsset(settingsPageImportPattern, appSource)
+	if settingsAsset == "" {
+		return nil, errors.New("当前 Codex 构建中未找到设置模块入口")
+	}
+	settingsModuleURL, err := resolveModuleURL(appModuleURL, settingsAsset)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.importModule(ctx, settingsModuleURL); err != nil {
+		return nil, fmt.Errorf("无法加载 Codex 设置模块：%w", err)
+	}
+	settingsScriptID := s.waitForScript(ctx, settingsModuleURL)
+	if settingsScriptID == "" {
+		return nil, errors.New("Codex 设置模块没有出现在调试器中")
+	}
+	if s.settingsScriptID != settingsScriptID {
+		settingsSource, err := s.getScriptSource(ctx, settingsScriptID)
+		if err != nil {
+			return nil, err
+		}
+		visibilityAsset := visibilityAssetPattern.FindString(settingsSource)
+		if visibilityAsset == "" {
+			return nil, errors.New("当前 Codex 构建中未找到设置可见性模块")
+		}
+		visibilityURL, err := resolveModuleURL(settingsModuleURL, visibilityAsset)
+		if err != nil {
+			return nil, err
+		}
+		s.settingsScriptID = settingsScriptID
+		s.settingsAppModuleURL = appModuleURL
+		s.settingsVisibilityURL = visibilityURL
+	}
+	return &SettingsAdapterConfiguration{
+		AppModuleURL: s.settingsAppModuleURL, VisibilityModuleURL: s.settingsVisibilityURL,
+		Sections: sections,
+	}, nil
+}
+
+func matchAsset(pattern *regexp.Regexp, source string) string {
+	match := pattern.FindStringSubmatch(source)
+	if len(match) == 2 {
+		return match[1]
+	}
+	return pattern.FindString(source)
+}
+
+func (s *capabilitySession) findScript(pattern *regexp.Regexp) (string, string) {
+	s.scriptMu.RLock()
+	defer s.scriptMu.RUnlock()
+	for scriptURL, scriptID := range s.scripts {
+		if pattern.MatchString(scriptURL) {
+			return scriptURL, scriptID
+		}
+	}
+	return "", ""
+}
+
+func (s *capabilitySession) waitForMatchingScript(
+	ctx context.Context,
+	pattern *regexp.Regexp,
+) (string, string) {
+	if scriptURL, scriptID := s.findScript(pattern); scriptID != "" {
+		return scriptURL, scriptID
+	}
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ""
+		case <-timer.C:
+			return "", ""
+		case <-ticker.C:
+			if scriptURL, scriptID := s.findScript(pattern); scriptID != "" {
+				return scriptURL, scriptID
+			}
+		}
+	}
+}
+
+func (s *capabilitySession) waitForScript(ctx context.Context, scriptURL string) string {
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	for {
+		s.scriptMu.RLock()
+		scriptID := s.scripts[scriptURL]
+		s.scriptMu.RUnlock()
+		if scriptID != "" {
+			return scriptID
+		}
+		select {
+		case <-ctx.Done():
+			return ""
+		case <-timer.C:
+			return ""
+		case <-ticker.C:
+		}
+	}
+}
+
+func (s *capabilitySession) getScriptSource(ctx context.Context, scriptID string) (string, error) {
+	raw, err := s.call(ctx, "Debugger.getScriptSource", map[string]any{"scriptId": scriptID})
+	if err != nil {
+		return "", err
+	}
+	result := struct {
+		ScriptSource string `json:"scriptSource"`
+	}{}
+	if err := json.Unmarshal(raw, &result); err != nil || result.ScriptSource == "" {
+		return "", errors.New("Codex 设置模块源码无法读取")
+	}
+	return result.ScriptSource, nil
+}
+
+func (s *capabilitySession) importModule(ctx context.Context, moduleURL string) error {
+	expression := fmt.Sprintf("import(%s).then(() => true)", JSONLiteral(moduleURL))
+	raw, err := s.call(ctx, "Runtime.evaluate", map[string]any{
+		"expression": expression, "returnByValue": true, "awaitPromise": true, "userGesture": false,
+	})
+	if err != nil {
+		return err
+	}
+	result := map[string]any{}
+	if json.Unmarshal(raw, &result) != nil || result["exceptionDetails"] != nil {
+		return errors.New("模块动态导入失败")
+	}
+	return nil
+}
+
+func resolveModuleURL(baseURL, relative string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	reference, err := url.Parse(relative)
+	if err != nil {
+		return "", err
+	}
+	return base.ResolveReference(reference).String(), nil
+}

--- a/backend/internal/core/cdp_settings_test.go
+++ b/backend/internal/core/cdp_settings_test.go
@@ -1,0 +1,642 @@
+package core
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSettingsModuleAssetDiscovery(t *testing.T) {
+	appSource := `const page=()=>import(` + "`" + `./settings-page-ABC_123.js` + "`" + `);`
+	settingsSource := `import{n as e}from"./use-visible-settings-sections-DEF-456.js";`
+	if got := matchAsset(settingsPageImportPattern, appSource); got != "./settings-page-ABC_123.js" {
+		t.Fatalf("settings page asset = %q", got)
+	}
+	if got := visibilityAssetPattern.FindString(settingsSource); got != "./use-visible-settings-sections-DEF-456.js" {
+		t.Fatalf("visibility asset = %q", got)
+	}
+	if got := matchAsset(settingsPageImportPattern, "const settings = [];"); got != "" {
+		t.Fatalf("unexpected asset = %q", got)
+	}
+}
+
+func TestSettingsModuleAssetFixtures(t *testing.T) {
+	appPath := os.Getenv("CODEX_TWEAKS_APP_INITIAL_FIXTURE")
+	settingsPath := os.Getenv("CODEX_TWEAKS_SETTINGS_PAGE_FIXTURE")
+	if appPath == "" || settingsPath == "" {
+		t.Skip("set app-initial and settings-page fixture paths for a Codex compatibility check")
+	}
+	appSource, err := os.ReadFile(appPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settingsSource, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if matchAsset(settingsPageImportPattern, string(appSource)) == "" ||
+		visibilityAssetPattern.FindString(string(settingsSource)) == "" {
+		t.Fatal("current Codex module assets were not discovered")
+	}
+}
+
+func TestSettingsAdapterLiveCDP(t *testing.T) {
+	if os.Getenv("CODEX_TWEAKS_LIVE_CDP") != "1" {
+		t.Skip("set CODEX_TWEAKS_LIVE_CDP=1 for a live in-memory compatibility check")
+	}
+	service := NewCDPService(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	targets, err := service.discoverTargets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	permissions, err := normalizeUISettingsSectionPermissions(json.RawMessage(
+		`{"sections":[{"id":"compatibility-test","title":"Compatibility Test"}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := bindUISettingsSectionPermissions("compatibility-test", permissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := Payload{Packages: []CompiledPackage{{
+		ID: "compatibility-test",
+		Capabilities: map[string]GrantedCapability{
+			UISettingsSectionCapabilityID: {
+				Version: UISettingsSectionCapabilityVersion, Permissions: bound,
+			},
+		},
+	}}}
+	errorsByTarget := []string{}
+	for _, target := range targets {
+		if strings.Contains(target.URL, "initialRoute=") {
+			continue
+		}
+		session, openError := openCapabilitySession(
+			ctx, service.dialer, service.AllowedOrigin, target, service.broker, nil,
+		)
+		if openError != nil {
+			errorsByTarget = append(errorsByTarget, target.ID+": "+openError.Error())
+			continue
+		}
+		configuration, adapterError := session.ensureSettingsAdapter(ctx, payload)
+		session.Close()
+		if adapterError == nil && configuration != nil {
+			return
+		}
+		if adapterError != nil {
+			errorsByTarget = append(errorsByTarget, target.ID+": "+adapterError.Error())
+		}
+	}
+	t.Fatalf("no live Codex target accepted ui.settings-section@1.0.0: %s", strings.Join(errorsByTarget, "; "))
+}
+
+func TestSettingsAdapterLiveInjection(t *testing.T) {
+	if os.Getenv("CODEX_TWEAKS_LIVE_SETTINGS_INJECTION") != "1" {
+		t.Skip("set CODEX_TWEAKS_LIVE_SETTINGS_INJECTION=1 for a visible live settings check")
+	}
+	service := NewCDPService(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	targets, err := service.discoverTargets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var target *CDPTarget
+	for index := range targets {
+		if !strings.Contains(targets[index].URL, "initialRoute=") {
+			target = &targets[index]
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("no main Codex target")
+	}
+	original, err := service.evaluate(ctx, `(() => ({
+      settingsSlug: document.querySelector(
+        'button[data-settings-panel-slug][aria-current="page"]'
+      )?.dataset?.settingsPanelSlug ?? ""
+    }))()`, *target.WebSocketDebuggerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalSettingsSlug, _ := original["settingsSlug"].(string)
+	appModuleURL := ""
+	openedCustom := false
+	restoreNavigation := func(restoreContext context.Context) {
+		if !openedCustom || appModuleURL == "" {
+			return
+		}
+		restoreExpression := fmt.Sprintf(`(async () => {
+          const appModule = await import(%s);
+          const bus = Object.values(appModule).find((value) =>
+            value && typeof value === "object"
+            && value.handlers instanceof Map
+            && typeof value.dispatchHostMessage === "function"
+          );
+          if (!bus) return { restored: false };
+          %s
+          return { restored: true };
+        })()`, JSONLiteral(appModuleURL), func() string {
+			if originalSettingsSlug != "" {
+				return fmt.Sprintf(`bus.dispatchHostMessage({
+              type: "navigate-to-route",
+              path: "/settings/" + %s,
+              replace: true
+            });`, JSONLiteral(originalSettingsSlug))
+			}
+			return `bus.dispatchHostMessage({ type: "navigate-back" });`
+		}())
+		_, _ = service.evaluate(restoreContext, restoreExpression, *target.WebSocketDebuggerURL)
+		openedCustom = false
+	}
+	defer func() {
+		_, _ = service.evaluate(context.Background(), CleanupScript, *target.WebSocketDebuggerURL)
+		restoreNavigation(context.Background())
+		_, _ = service.evaluate(context.Background(), `(() => {
+          if (globalThis.__CODEX_TWEAKS_UI_LIVE_ERRORS__?.originalConsoleError) {
+            console.error = globalThis.__CODEX_TWEAKS_UI_LIVE_ERRORS__.originalConsoleError;
+          }
+          delete globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__;
+          delete globalThis.__CODEX_TWEAKS_UI_LIVE_ERRORS__;
+          delete globalThis.__CODEX_TWEAKS_SETTINGS_ROUTE_ELEMENT__;
+          delete globalThis.__CODEX_TWEAKS_ROUTER_CANDIDATE__;
+          return { restored: true };
+        })()`, *target.WebSocketDebuggerURL)
+		service.mu.Lock()
+		service.closeAllCapabilitySessionsLocked()
+		service.mu.Unlock()
+	}()
+	requirements := map[string]CapabilityRequirement{
+		UISettingsSectionCapabilityID: {
+			Version: "^1.0.0",
+			Permissions: json.RawMessage(`{
+              "sections":[{
+                "id":"compatibility-test",
+                "title":"Compatibility Test",
+                "group":"personal",
+                "icon":"personalization",
+                "after":"personalization"
+              }]
+            }`),
+		},
+	}
+	grants, err := resolvePackageCapabilities("compatibility-test", requirements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := Payload{Version: "live-settings-test", Packages: []CompiledPackage{{
+		ID: "compatibility-test", Name: "compatibility-test", Version: "1.0.0",
+		Capabilities: grants,
+		JavaScript: `module.exports.activate = ({ capabilities }) => {
+          const settings = capabilities.require("ui.settings-section");
+          globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__ = settings.register({
+            id: "compatibility-test",
+            mount(container) {
+              container.textContent = "Codex Tweaks live settings route";
+              return () => container.replaceChildren();
+            }
+          });
+        };`,
+	}}}
+	bridgeID, tokens, configuration, err := service.capabilityBridgeForTargetLocked(ctx, *target, payload)
+	if err != nil || configuration == nil {
+		t.Fatalf("settings bridge unavailable: %v %#v", err, configuration)
+	}
+	appModuleURL = configuration.AppModuleURL
+	if _, err := service.evaluate(ctx, `(() => {
+      const records = [];
+      const originalConsoleError = console.error;
+      console.error = (...args) => {
+        records.push(args.map((value) => {
+          try { return value instanceof Error ? value.stack : String(value); }
+          catch (_) { return "<unprintable>"; }
+        }).join("\n").slice(0, 8000));
+        return originalConsoleError.apply(console, args);
+      };
+      globalThis.__CODEX_TWEAKS_UI_LIVE_ERRORS__ = { originalConsoleError, records };
+      return { installed: true };
+    })()`, *target.WebSocketDebuggerURL); err != nil {
+		t.Fatal(err)
+	}
+	result, err := service.evaluate(
+		ctx,
+		injectionScriptWithCapabilities(payload, 0, bridgeID, tokens, configuration),
+		*target.WebSocketDebuggerURL,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packageErrors, _ := result["packageErrors"].([]any); len(packageErrors) != 0 {
+		t.Fatalf("live package errors: %#v (adapter: %#v)", packageErrors, result["settingsAdapterError"])
+	}
+	diagnosticsExpression := fmt.Sprintf(`(async () => {
+      const slug = globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__?.slug;
+      const appModule = await import(%s);
+      const visibilityModule = await import(%s);
+      const registry = Object.values(appModule).find((value) =>
+        Array.isArray(value)
+        && value.some((entry) => entry?.slug === "general-settings")
+        && value.some((entry) => entry?.slug === "personalization")
+      );
+      const iconMap = Object.values(visibilityModule).find((value) =>
+        value && typeof value === "object"
+        && typeof value.personalization === "function"
+        && typeof value["general-settings"] === "function"
+      );
+      const fibers = [];
+      for (const element of document.querySelectorAll("*")) {
+        for (const key of Object.getOwnPropertyNames(element)) {
+          if (key.startsWith("__reactContainer$") || key.startsWith("__reactFiber$")) {
+            fibers.push(element[key]?.current ?? element[key]);
+          }
+        }
+      }
+      const seenFibers = new Set();
+      let routeRegistered = false;
+      const flatten = (node, result = [], seen = new Set()) => {
+        if (Array.isArray(node)) {
+          for (const child of node) flatten(child, result, seen);
+        } else if (node && typeof node === "object" && !seen.has(node)) {
+          seen.add(node);
+          if (node.props) {
+            result.push(node);
+            flatten(node.props.children, result, seen);
+          }
+        }
+        return result;
+      };
+      while (fibers.length && seenFibers.size < 200000) {
+        const fiber = fibers.shift();
+        if (!fiber || typeof fiber !== "object" || seenFibers.has(fiber)) continue;
+        seenFibers.add(fiber);
+        fibers.push(fiber.child, fiber.sibling, fiber.return, fiber.alternate);
+        for (const props of [fiber.memoizedProps, fiber.pendingProps]) {
+          const elements = flatten(props?.children);
+          if (
+            elements.some((element) => element?.props?.path === "/settings")
+            && elements.some((element) => element?.props?.path === slug)
+          ) routeRegistered = true;
+        }
+      }
+      return {
+        slug,
+        customIconType: typeof iconMap?.[slug],
+        registryHasSlug: registry?.some((entry) => entry?.slug === slug),
+        registryOwnFilter: Object.prototype.hasOwnProperty.call(registry ?? {}, "filter"),
+        routeRegistered,
+        visibleWhenRejected: registry?.filter(() => false).some((entry) => entry?.slug === slug)
+      };
+    })()`, JSONLiteral(configuration.AppModuleURL), JSONLiteral(configuration.VisibilityModuleURL))
+	diagnostics, diagnosticError := service.evaluate(ctx, diagnosticsExpression, *target.WebSocketDebuggerURL)
+	if diagnosticError != nil {
+		t.Fatal(diagnosticError)
+	}
+	if diagnostics["registryHasSlug"] != true || diagnostics["registryOwnFilter"] != true ||
+		diagnostics["routeRegistered"] != true || diagnostics["visibleWhenRejected"] != true ||
+		diagnostics["customIconType"] != "function" {
+		t.Fatalf("settings adapter did not mutate the native registries: %#v", diagnostics)
+	}
+	if _, err := service.evaluate(ctx, `(() => {
+      globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__.open();
+      return { opened: true };
+    })()`, *target.WebSocketDebuggerURL); err != nil {
+		t.Fatal(err)
+	}
+	openedCustom = true
+	var observed map[string]any
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		observed, err = service.evaluate(ctx, `(() => {
+          const slug = globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__?.slug;
+          const buttons = [...document.querySelectorAll("button[data-settings-panel-slug]")];
+          const button = buttons.find((candidate) => candidate.dataset.settingsPanelSlug === slug);
+          const personalization = buttons.findIndex(
+            (candidate) => candidate.dataset.settingsPanelSlug === "personalization"
+          );
+          return {
+            slug,
+            path: location.pathname,
+            buttonLabel: button?.textContent?.trim() ?? "",
+            buttonAria: button?.getAttribute("aria-label") ?? "",
+            buttonIndex: buttons.indexOf(button),
+            personalizationIndex: personalization,
+            content: document.querySelector(
+              "[data-codex-tweaks-settings-section-host]"
+            )?.textContent ?? "",
+            bodyText: document.body?.innerText?.slice(0, 200) ?? "",
+            errors: globalThis.__CODEX_TWEAKS_UI_LIVE_ERRORS__?.records ?? []
+          };
+		})()`, *target.WebSocketDebuggerURL)
+		if err == nil && observed["content"] == "Codex Tweaks live settings route" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observed["buttonLabel"] != "Compatibility Test" || observed["buttonAria"] != "Compatibility Test" ||
+		observed["content"] != "Codex Tweaks live settings route" {
+		t.Fatalf("live settings section was not native and routable: %#v", observed)
+	}
+	buttonIndex, _ := observed["buttonIndex"].(float64)
+	personalizationIndex, _ := observed["personalizationIndex"].(float64)
+	if buttonIndex != personalizationIndex+1 {
+		t.Fatalf("live settings placement is wrong: %#v", observed)
+	}
+	if _, err := service.evaluate(ctx, CleanupScript, *target.WebSocketDebuggerURL); err != nil {
+		t.Fatal(err)
+	}
+	var cleaned map[string]any
+	cleanupDeadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(cleanupDeadline) {
+		cleaned, err = service.evaluate(ctx, `(() => {
+          const slug = globalThis.__CODEX_TWEAKS_UI_LIVE_TEST__?.slug;
+          return {
+            adapterPresent: Boolean(globalThis.__CODEX_TWEAKS_SETTINGS_SECTIONS__),
+            buttonPresent: [...document.querySelectorAll("button[data-settings-panel-slug]")]
+              .some((button) => button.dataset.settingsPanelSlug === slug),
+            hostPresent: [...document.querySelectorAll("[data-codex-tweaks-settings-section-host]")]
+              .some((host) => host.getAttribute("data-codex-tweaks-settings-section-host") === slug),
+            labelHookPresent: Object.prototype.hasOwnProperty.call(Object.prototype, slug)
+          };
+        })()`, *target.WebSocketDebuggerURL)
+		if err == nil && cleaned["adapterPresent"] == false && cleaned["buttonPresent"] == false &&
+			cleaned["hostPresent"] == false && cleaned["labelHookPresent"] == false {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cleaned["adapterPresent"] != false || cleaned["buttonPresent"] != false ||
+		cleaned["hostPresent"] != false || cleaned["labelHookPresent"] != false {
+		t.Fatalf("settings adapter did not restore the native registries: %#v", cleaned)
+	}
+	restoreNavigation(ctx)
+}
+
+func TestRandomBackgroundPackageLiveRuntime(t *testing.T) {
+	if os.Getenv("CODEX_TWEAKS_LIVE_RANDOM_BACKGROUND") != "1" {
+		t.Skip("set CODEX_TWEAKS_LIVE_RANDOM_BACKGROUND=1 to inspect the running migrated package")
+	}
+	service := NewCDPService(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	targets, err := service.discoverTargets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var target *CDPTarget
+	for index := range targets {
+		if !strings.Contains(targets[index].URL, "initialRoute=") {
+			target = &targets[index]
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("no main Codex target")
+	}
+	permissions, err := normalizeUISettingsSectionPermissions(json.RawMessage(
+		`{"sections":[{"id":"random-background","title":"随机背景"}]}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := bindUISettingsSectionPermissions("codex-random-background", permissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := UISettingsSectionPermissions{}
+	if err := json.Unmarshal(bound, &settings); err != nil {
+		t.Fatal(err)
+	}
+	slug := settings.Sections[0].Slug
+	expression := fmt.Sprintf(`(() => {
+      const runtime = globalThis.__CODEX_TWEAKS__;
+      const adapter = globalThis.__CODEX_TWEAKS_SETTINGS_SECTIONS__;
+      const packageError = runtime?.packageErrors?.find(
+        (entry) => entry?.id === "codex-random-background"
+      );
+      return {
+        runtimePresent: Boolean(runtime),
+        runtimeVersion: runtime?.version ?? "",
+        packageError: packageError?.message ?? "",
+        settingsRegistered: adapter?.has?.(%s) === true,
+        activeSettingsSlug: document.querySelector(
+          'button[data-settings-panel-slug][aria-current="page"]'
+        )?.dataset?.settingsPanelSlug ?? "",
+        settingsButtonSlugs: [...document.querySelectorAll(
+          'button[data-settings-panel-slug]'
+        )].map((button) => button.dataset.settingsPanelSlug),
+        panelHostSlug: document.querySelector(
+          '[data-codex-tweaks-rbgp-settings-panel]'
+        )?.closest('[data-codex-tweaks-settings-section-host]')
+          ?.getAttribute('data-codex-tweaks-settings-section-host') ?? "",
+        packageRootPresent: Boolean(document.querySelector(
+          '[data-codex-tweaks-package-root="codex-random-background"]'
+        )),
+        packageRootCount: document.querySelectorAll(
+          '[data-codex-tweaks-package-root="codex-random-background"]'
+        ).length,
+        packageStylePresent: Boolean(document.querySelector(
+          'style[data-codex-tweaks-package-style="codex-random-background"]'
+        )),
+        packageStyleCount: document.querySelectorAll(
+          'style[data-codex-tweaks-package-style="codex-random-background"]'
+        ).length,
+        legacyEmbeds: [...document.querySelectorAll(
+          '[data-codex-tweaks-rbgp-embed]'
+        )].map((element) => ({
+          parentTag: element.parentElement?.tagName ?? "",
+          parentClass: element.parentElement?.className ?? "",
+          text: element.textContent?.trim()?.slice(0, 80) ?? ""
+        }))
+      };
+    })()`, JSONLiteral(slug))
+	observed, err := service.evaluate(ctx, expression, *target.WebSocketDebuggerURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("running random-background diagnostics: %#v", observed)
+	if observed["runtimePresent"] != true || observed["packageError"] != "" ||
+		observed["settingsRegistered"] != true || observed["packageRootPresent"] != true ||
+		observed["packageStylePresent"] != true {
+		t.Fatalf("migrated package is not fully active: %#v", observed)
+	}
+}
+
+func TestRandomBackgroundSettingsRouteLive(t *testing.T) {
+	if os.Getenv("CODEX_TWEAKS_LIVE_RANDOM_BACKGROUND_ROUTE") != "1" {
+		t.Skip("set CODEX_TWEAKS_LIVE_RANDOM_BACKGROUND_ROUTE=1 to verify settings route ownership")
+	}
+	service := NewCDPService(nil)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	targets, err := service.discoverTargets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var target *CDPTarget
+	for index := range targets {
+		if !strings.Contains(targets[index].URL, "initialRoute=") {
+			target = &targets[index]
+			break
+		}
+	}
+	if target == nil {
+		t.Fatal("no main Codex target")
+	}
+	permissions, err := normalizeUISettingsSectionPermissions(json.RawMessage(`{
+      "sections":[{
+        "id":"random-background",
+        "title":"随机背景",
+        "group":"personal",
+        "icon":"personalization",
+        "after":"personalization"
+      }]
+    }`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	bound, err := bindUISettingsSectionPermissions("codex-random-background", permissions)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settings := UISettingsSectionPermissions{}
+	if err := json.Unmarshal(bound, &settings); err != nil {
+		t.Fatal(err)
+	}
+	slug := settings.Sections[0].Slug
+	payload := Payload{Packages: []CompiledPackage{{
+		ID: "codex-random-background",
+		Capabilities: map[string]GrantedCapability{
+			UISettingsSectionCapabilityID: {
+				Version: UISettingsSectionCapabilityVersion, Permissions: bound,
+			},
+		},
+	}}}
+	session, err := openCapabilitySession(
+		ctx, service.dialer, service.AllowedOrigin, *target, service.broker, nil,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	configuration, err := session.ensureSettingsAdapter(ctx, payload)
+	defer session.Close()
+	if err != nil || configuration == nil {
+		t.Fatalf("settings module unavailable: %v %#v", err, configuration)
+	}
+
+	observe := func() map[string]any {
+		observed, evaluateError := service.evaluate(ctx, `(() => {
+          const panel = document.querySelector('[data-codex-tweaks-rbgp-settings-panel]');
+          return {
+            activeSlug: document.querySelector(
+              'button[data-settings-panel-slug][aria-current="page"]'
+            )?.dataset?.settingsPanelSlug ?? "",
+            buttonSlugs: [...document.querySelectorAll(
+              'button[data-settings-panel-slug]'
+            )].map((button) => button.dataset.settingsPanelSlug),
+            panelCount: document.querySelectorAll(
+              '[data-codex-tweaks-rbgp-settings-panel]'
+            ).length,
+            legacyEmbedCount: document.querySelectorAll(
+              '[data-codex-tweaks-rbgp-embed]'
+            ).length,
+            legacyEmbedDetails: [...document.querySelectorAll(
+              '[data-codex-tweaks-rbgp-embed]'
+            )].map((element) => ({
+              parentTag: element.parentElement?.tagName ?? "",
+              parentClass: element.parentElement?.className ?? "",
+              text: element.textContent?.trim()?.slice(0, 80) ?? ""
+            })),
+            panelHostSlug: panel?.closest(
+              '[data-codex-tweaks-settings-section-host]'
+            )?.getAttribute('data-codex-tweaks-settings-section-host') ?? "",
+            panelText: panel?.textContent?.trim()?.slice(0, 120) ?? ""
+          };
+        })()`, *target.WebSocketDebuggerURL)
+		if evaluateError != nil {
+			t.Fatal(evaluateError)
+		}
+		return observed
+	}
+	original := observe()
+	originalSlug, _ := original["activeSlug"].(string)
+	navigate := func(sectionSlug string, replace bool) {
+		expression := fmt.Sprintf(`(async () => {
+          const appModule = await import(%s);
+          const bus = Object.values(appModule).find((value) =>
+            value && typeof value === "object"
+            && value.handlers instanceof Map
+            && typeof value.dispatchHostMessage === "function"
+          );
+          if (!bus) throw new Error("Codex navigation bus unavailable");
+          bus.dispatchHostMessage({
+            type: "navigate-to-route",
+            path: "/settings/" + %s,
+            replace: %s
+          });
+          return { navigated: true };
+        })()`, JSONLiteral(configuration.AppModuleURL), JSONLiteral(sectionSlug), JSONLiteral(replace))
+		if _, evaluateError := service.evaluate(ctx, expression, *target.WebSocketDebuggerURL); evaluateError != nil {
+			t.Fatal(evaluateError)
+		}
+	}
+	restore := func() {
+		if originalSlug != "" {
+			navigate(originalSlug, true)
+			return
+		}
+		expression := fmt.Sprintf(`(async () => {
+          const appModule = await import(%s);
+          const bus = Object.values(appModule).find((value) =>
+            value && typeof value === "object"
+            && value.handlers instanceof Map
+            && typeof value.dispatchHostMessage === "function"
+          );
+          bus?.dispatchHostMessage({ type: "navigate-back" });
+          return { restored: Boolean(bus) };
+        })()`, JSONLiteral(configuration.AppModuleURL))
+		_, _ = service.evaluate(context.Background(), expression, *target.WebSocketDebuggerURL)
+	}
+	defer restore()
+
+	waitFor := func(expectedSlug string, expectedPanelCount, expectedLegacyEmbedCount float64) map[string]any {
+		deadline := time.Now().Add(3 * time.Second)
+		var observed map[string]any
+		for time.Now().Before(deadline) {
+			observed = observe()
+			if observed["activeSlug"] == expectedSlug &&
+				observed["panelCount"] == expectedPanelCount &&
+				observed["legacyEmbedCount"] == expectedLegacyEmbedCount {
+				return observed
+			}
+			time.Sleep(50 * time.Millisecond)
+		}
+		return observed
+	}
+
+	navigate(slug, originalSlug != "")
+	randomPage := waitFor(slug, 1, 0)
+	if randomPage["panelHostSlug"] != slug {
+		t.Fatalf("random-background panel is not owned by its route: %#v", randomPage)
+	}
+	navigate("personalization", true)
+	personalizationPage := waitFor("personalization", 0, 0)
+	if personalizationPage["panelCount"] != float64(0) ||
+		personalizationPage["legacyEmbedCount"] != float64(0) {
+		t.Fatalf("random-background settings leaked into personalization: %#v", personalizationPage)
+	}
+	t.Logf("random page: %#v", randomPage)
+	t.Logf("personalization page: %#v", personalizationPage)
+}

--- a/backend/internal/core/controller.go
+++ b/backend/internal/core/controller.go
@@ -257,7 +257,8 @@ func (c *Controller) Snapshot() AppSnapshot {
 	})
 	return AppSnapshot{
 		ProtocolVersion: ProtocolVersion, Presentation: presentation, Status: c.status,
-		Enabled: c.config.Enabled, DeveloperMode: c.config.DeveloperMode, Packages: packageViews,
+		Enabled: c.config.Enabled, DeveloperMode: c.config.DeveloperMode,
+		AvailableCapabilities: AvailableCapabilities(), Packages: packageViews,
 		DisabledPackageIDs: sortedTrueKeys(c.disabledPackageIDs), BuildingPackageIDs: sortedTrueKeys(c.buildingPackageIDs),
 		ExportingPackageIDs: sortedTrueKeys(c.exportingPackageIDs),
 		PackageBuildErrors:  cloneStringMap(c.packageBuildErrors), PackageRuntimeErrors: cloneStringMap(c.packageRuntimeErrors),

--- a/backend/internal/core/controller_types.go
+++ b/backend/internal/core/controller_types.go
@@ -118,6 +118,7 @@ type AppSnapshot struct {
 	Status                     AppStatus                     `json:"status"`
 	Enabled                    bool                          `json:"enabled"`
 	DeveloperMode              bool                          `json:"developerMode"`
+	AvailableCapabilities      []CapabilityDescriptor        `json:"availableCapabilities"`
 	Packages                   []PackageView                 `json:"packages"`
 	DisabledPackageIDs         []string                      `json:"disabledPackageIDs"`
 	BuildingPackageIDs         []string                      `json:"buildingPackageIDs"`

--- a/backend/internal/core/injection.go
+++ b/backend/internal/core/injection.go
@@ -14,6 +14,16 @@ const CleanupScript = `(() => {
 })()`
 
 func InjectionScript(payload Payload, forceGeneration int) string {
+	return injectionScriptWithCapabilities(payload, forceGeneration, "", map[string]string{}, nil)
+}
+
+func injectionScriptWithCapabilities(
+	payload Payload,
+	forceGeneration int,
+	bridgeSessionID string,
+	capabilityTokens map[string]string,
+	settingsAdapterConfiguration *SettingsAdapterConfiguration,
+) string {
 	effectiveVersion := payload.Version
 	if forceGeneration != 0 {
 		effectiveVersion = fmt.Sprintf("%s-force-%d", payload.Version, forceGeneration)
@@ -22,14 +32,21 @@ func InjectionScript(payload Payload, forceGeneration int) string {
 	executions := make([]string, 0, len(payload.Packages))
 	for _, pkg := range payload.Packages {
 		setups = append(setups, packageSetupScript(pkg))
-		executions = append(executions, packageExecutionScript(pkg))
+		executions = append(executions, packageExecutionScript(pkg, capabilityTokens[pkg.ID]))
 	}
 	return fmt.Sprintf(`(async () => {
   const key = "__CODEX_TWEAKS__";
   const version = %s;
+  const bridgeSessionID = %s;
+  const settingsAdapterConfiguration = %s;
+  const settingsAdapterKey = JSON.stringify(settingsAdapterConfiguration ?? null);
+  const settingsAdapterExpected = Boolean(settingsAdapterConfiguration?.sections?.length);
   const existing = globalThis[key];
   if (
     existing?.version === version &&
+    existing?.bridgeSessionID === bridgeSessionID &&
+    existing?.settingsAdapterKey === settingsAdapterKey &&
+    (!settingsAdapterExpected || existing?.settingsAdapterReady === true) &&
     document.getElementById("codex-tweaks-root")
   ) {
     return {
@@ -48,6 +65,606 @@ func InjectionScript(payload Payload, forceGeneration int) string {
   (document.body || document.documentElement).appendChild(host);
   const packageStates = new Map();
   const packageErrors = [];
+  const capabilityPending = new Map();
+  const capabilityPendingLimit = 64;
+  const capabilityBinding = bridgeSessionID
+    ? globalThis[%s]
+    : null;
+  let capabilitySequence = 0;
+
+  const capabilityError = (message, code) => {
+    const error = new Error(message);
+    if (code) error.code = code;
+    return error;
+  };
+
+  const invokeCapability = (token, capability, method, parameters) => {
+    if (!bridgeSessionID || typeof capabilityBinding !== "function") {
+      return Promise.reject(capabilityError(
+        "Codex Tweaks host capability bridge is unavailable",
+        "bridge_unavailable"
+      ));
+    }
+    if (capabilityPending.size >= capabilityPendingLimit) {
+      return Promise.reject(capabilityError(
+        "Capability bridge is busy",
+        "busy"
+      ));
+    }
+    const randomPart = globalThis.crypto?.randomUUID?.()
+      ?? (Date.now().toString(36) + "-" + Math.random().toString(36).slice(2));
+    const id = bridgeSessionID + ":" + (++capabilitySequence) + ":" + randomPart;
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        capabilityPending.delete(id);
+        reject(capabilityError("Capability request timed out", "timeout"));
+      }, 20000);
+      capabilityPending.set(id, { resolve, reject, timeout });
+      try {
+        capabilityBinding(JSON.stringify({
+          v: 1,
+          id,
+          token,
+          capability,
+          method,
+          parameters: parameters ?? {}
+        }));
+      } catch (error) {
+        clearTimeout(timeout);
+        capabilityPending.delete(id);
+        reject(error);
+      }
+    });
+  };
+
+  let settingsAdapter = null;
+  let settingsAdapterError = null;
+  const installSettingsAdapter = async (configuration) => {
+    if (!configuration?.sections?.length) return null;
+    const globalKey = "__CODEX_TWEAKS_SETTINGS_SECTIONS__";
+    try { globalThis[globalKey]?.cleanup?.(); } catch (_) {}
+    const descriptors = new Map(
+      configuration.sections.map((section) => [section.slug, Object.freeze({ ...section })])
+    );
+    const renderers = new Map();
+    const mounted = new Map();
+    const routeElements = new Map();
+    const previousIcons = new Map();
+    const labelMessages = new Map();
+    const previousLabels = new Map();
+    const prototypeLabelHooks = new Map();
+    let registry = null;
+    let registryFilter = null;
+    let originalRegistryFilterDescriptor = null;
+    let iconMap = null;
+    let labelRegistry = null;
+    let groupRegistry = null;
+    let navigationBus = null;
+    let settingsRouteChildren = null;
+    let routeTemplate = null;
+
+    const originalArrayMapDescriptor = Object.getOwnPropertyDescriptor(Array.prototype, "map");
+    const originalArrayMap = originalArrayMapDescriptor?.value;
+    let groupMapInterceptor = null;
+
+    const restoreGroupMapInterceptor = () => {
+      if (groupMapInterceptor && Array.prototype.map === groupMapInterceptor) {
+        Object.defineProperty(Array.prototype, "map", originalArrayMapDescriptor);
+      }
+      groupMapInterceptor = null;
+    };
+    const isSettingsGroupRegistry = (value) =>
+      Array.isArray(value)
+      && value.some((group) => group?.key === "personal" && group.slugs?.includes?.("personalization"))
+      && value.some((group) => group?.key === "integrations")
+      && value.some((group) => group?.key === "coding");
+    const applyGroupPlacements = () => {
+      if (!groupRegistry) return;
+      for (const group of groupRegistry) {
+        if (!Array.isArray(group?.slugs)) continue;
+        for (let index = group.slugs.length - 1; index >= 0; index -= 1) {
+          if (descriptors.has(group.slugs[index])) group.slugs.splice(index, 1);
+        }
+      }
+      for (const descriptor of descriptors.values()) {
+        if (!renderers.has(descriptor.slug)) continue;
+        const group = groupRegistry.find((candidate) => candidate?.key === descriptor.group)
+          ?? groupRegistry.find((candidate) => candidate?.key === "personal")
+          ?? groupRegistry[0];
+        if (!Array.isArray(group?.slugs)) continue;
+        const afterIndex = descriptor.after ? group.slugs.indexOf(descriptor.after) : -1;
+        group.slugs.splice(afterIndex >= 0 ? afterIndex + 1 : group.slugs.length, 0, descriptor.slug);
+      }
+    };
+    if (typeof originalArrayMap === "function") {
+      groupMapInterceptor = function (callback, thisArg) {
+        if (!groupRegistry && isSettingsGroupRegistry(this)) {
+          groupRegistry = this;
+          restoreGroupMapInterceptor();
+          applyGroupPlacements();
+        }
+        return originalArrayMap.call(this, callback, thisArg);
+      };
+      Object.defineProperty(Array.prototype, "map", {
+        ...originalArrayMapDescriptor,
+        value: groupMapInterceptor
+      });
+    }
+
+    const flattenReactElements = (node, result = [], seen = new Set(), depth = 0) => {
+      if (node == null || depth > 24) return result;
+      if (Array.isArray(node)) {
+        for (const child of node) flattenReactElements(child, result, seen, depth + 1);
+        return result;
+      }
+      if (typeof node !== "object" || seen.has(node)) return result;
+      seen.add(node);
+      if (node.props) {
+        result.push(node);
+        flattenReactElements(node.props.children, result, seen, depth + 1);
+      }
+      return result;
+    };
+    const findSettingsRouteElement = () => {
+      const fibers = [];
+      for (const element of document.querySelectorAll("*")) {
+        for (const key of Object.getOwnPropertyNames(element)) {
+          if (key.startsWith("__reactContainer$") || key.startsWith("__reactFiber$")) {
+            fibers.push(element[key]?.current ?? element[key]);
+          }
+        }
+      }
+      const seen = new Set();
+      while (fibers.length && seen.size < 200000) {
+        const fiber = fibers.shift();
+        if (!fiber || typeof fiber !== "object" || seen.has(fiber)) continue;
+        seen.add(fiber);
+        fibers.push(fiber.child, fiber.sibling, fiber.return, fiber.alternate);
+        for (const props of [fiber.memoizedProps, fiber.pendingProps]) {
+          const route = flattenReactElements(props?.children).find(
+            (candidate) =>
+              candidate?.props?.path === "/settings"
+              && Array.isArray(candidate.props.children)
+              && flattenReactElements(candidate.props.children).some(
+                (child) => child?.props?.path === "*"
+              )
+          );
+          if (route) return route;
+        }
+      }
+      return null;
+    };
+    const installRoute = (descriptor) => {
+      if (routeElements.has(descriptor.slug)) return;
+      const hostElement = {
+        ...routeTemplate,
+        key: null,
+        type: "div",
+        props: {
+          "aria-label": descriptor.title,
+          "data-codex-tweaks-settings-section-host": descriptor.slug,
+          className: "h-full min-h-0 overflow-y-auto",
+          role: "tabpanel"
+        },
+        _owner: null
+      };
+      const routeElement = {
+        ...routeTemplate,
+        key: "codex-tweaks-settings-" + descriptor.slug,
+        props: {
+          ...routeTemplate.props,
+          children: undefined,
+          element: hostElement,
+          index: undefined,
+          path: descriptor.slug
+        },
+        _owner: null
+      };
+      const wildcardIndex = settingsRouteChildren.findIndex(
+        (candidate) => candidate?.props?.path === "*"
+      );
+      settingsRouteChildren.splice(
+        wildcardIndex >= 0 ? wildcardIndex : settingsRouteChildren.length,
+        0,
+        routeElement
+      );
+      routeElements.set(descriptor.slug, routeElement);
+    };
+    const removeRoute = (slug) => {
+      const routeElement = routeElements.get(slug);
+      if (!routeElement || !settingsRouteChildren) return;
+      const index = settingsRouteChildren.indexOf(routeElement);
+      if (index >= 0) settingsRouteChildren.splice(index, 1);
+      routeElements.delete(slug);
+    };
+
+    const labelMessage = (descriptor) => Object.freeze({
+      id: "codex-tweaks.settings." + descriptor.slug,
+      defaultMessage: descriptor.title,
+      description: "Settings section supplied by Codex Tweaks package " + descriptor.packageID
+    });
+    const restorePrototypeLabelHook = (slug) => {
+      const hook = prototypeLabelHooks.get(slug);
+      if (!hook) return;
+      const current = Object.getOwnPropertyDescriptor(Object.prototype, slug);
+      if (current?.get === hook.getter) {
+        if (hook.previous) Object.defineProperty(Object.prototype, slug, hook.previous);
+        else delete Object.prototype[slug];
+      }
+      prototypeLabelHooks.delete(slug);
+    };
+    const writePrivateLabel = (slug, message) => {
+      if (!labelRegistry) return false;
+      if (!previousLabels.has(slug)) {
+        previousLabels.set(slug, Object.getOwnPropertyDescriptor(labelRegistry, slug) ?? null);
+      }
+      try {
+        Object.defineProperty(labelRegistry, slug, {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: message
+        });
+        restorePrototypeLabelHook(slug);
+        return labelRegistry[slug] === message;
+      } catch (_) {
+        return false;
+      }
+    };
+    const installLabel = (descriptor) => {
+      const slug = descriptor.slug;
+      const message = labelMessage(descriptor);
+      labelMessages.set(slug, message);
+      if (writePrivateLabel(slug, message) || prototypeLabelHooks.has(slug)) return;
+      const previous = Object.getOwnPropertyDescriptor(Object.prototype, slug) ?? null;
+      const getter = function () {
+        const generalMessage = this?.["general-settings"];
+        const personalizationMessage = this?.personalization;
+        if (
+          this && typeof this === "object"
+          && Object.prototype.hasOwnProperty.call(this, "general-settings")
+          && Object.prototype.hasOwnProperty.call(this, "personalization")
+          && generalMessage && typeof generalMessage === "object"
+          && typeof generalMessage.id === "string"
+          && personalizationMessage && typeof personalizationMessage === "object"
+          && typeof personalizationMessage.id === "string"
+        ) {
+          labelRegistry = this;
+          for (const [candidateSlug, candidateMessage] of labelMessages) {
+            writePrivateLabel(candidateSlug, candidateMessage);
+          }
+        }
+        return message;
+      };
+      Object.defineProperty(Object.prototype, slug, {
+        configurable: true,
+        enumerable: false,
+        get: getter
+      });
+      prototypeLabelHooks.set(slug, { getter, previous });
+    };
+    const removeLabel = (slug) => {
+      labelMessages.delete(slug);
+      restorePrototypeLabelHook(slug);
+      if (!labelRegistry || !previousLabels.has(slug)) return;
+      const current = Object.getOwnPropertyDescriptor(labelRegistry, slug);
+      const message = current?.value;
+      if (message?.id === "codex-tweaks.settings." + slug) {
+        const previous = previousLabels.get(slug);
+        if (previous) Object.defineProperty(labelRegistry, slug, previous);
+        else delete labelRegistry[slug];
+      }
+      previousLabels.delete(slug);
+    };
+
+    const cleanupMount = (element, record) => {
+      try { record?.cleanup?.(); } catch (_) {}
+      mounted.delete(element);
+    };
+    const scanMounts = () => {
+      for (const [element, record] of mounted) {
+        if (!element.isConnected || renderers.get(record.slug) !== record.renderer) {
+          cleanupMount(element, record);
+        }
+      }
+      for (const element of document.querySelectorAll("[data-codex-tweaks-settings-section-host]")) {
+        if (mounted.has(element)) continue;
+        const slug = element.getAttribute("data-codex-tweaks-settings-section-host");
+        const renderer = renderers.get(slug);
+        if (!renderer) continue;
+        try {
+          const cleanup = renderer.mount(element);
+          mounted.set(element, {
+            slug,
+            renderer,
+            cleanup: typeof cleanup === "function" ? cleanup : null
+          });
+        } catch (error) {
+          element.setAttribute("data-codex-tweaks-settings-section-error", "");
+          console.error("Codex Tweaks settings section failed to mount", error);
+        }
+      }
+    };
+    const observer = new MutationObserver(scanMounts);
+    const navigateToSettings = (path, replace = false) => {
+      if (!navigationBus) return;
+      navigationBus.dispatchHostMessage({ type: "navigate-to-route", path, replace });
+    };
+    const activeSettingsSlug = () => {
+      const activeButton = document.querySelector(
+        'button[data-settings-panel-slug][aria-current="page"]'
+      );
+      if (activeButton?.dataset?.settingsPanelSlug) {
+        return activeButton.dataset.settingsPanelSlug;
+      }
+      const activeHost = [...document.querySelectorAll(
+        "[data-codex-tweaks-settings-section-host]"
+      )].find((element) => element.isConnected);
+      return activeHost?.getAttribute("data-codex-tweaks-settings-section-host") ?? null;
+    };
+    const refreshSettingsRoute = () => {
+      const activeSlug = activeSettingsSlug();
+      if (activeSlug) navigateToSettings("/settings/" + activeSlug, true);
+    };
+
+    const adapter = {
+      has(slug) {
+        return renderers.has(slug);
+      },
+      register(packageID, sectionID, mount) {
+        const descriptor = [...descriptors.values()].find(
+          (candidate) => candidate.packageID === packageID && candidate.id === sectionID
+        );
+        if (!descriptor) {
+          throw new Error("Undeclared settings section: " + sectionID);
+        }
+        if (typeof mount !== "function") {
+          throw new TypeError("Settings section mount must be a function");
+        }
+        if (!registry || !iconMap || !navigationBus || !settingsRouteChildren || !routeTemplate) {
+          throw new Error("Codex settings module is not ready");
+        }
+        if (renderers.has(descriptor.slug)) {
+          throw new Error("Settings section is already registered: " + sectionID);
+        }
+        const renderer = { mount };
+        renderers.set(descriptor.slug, renderer);
+        installLabel(descriptor);
+        if (!registry.some((entry) => entry?.slug === descriptor.slug)) {
+          registry.push({ slug: descriptor.slug });
+        }
+        installRoute(descriptor);
+        if (!previousIcons.has(descriptor.slug)) {
+          const previousDescriptor = Object.getOwnPropertyDescriptor(iconMap, descriptor.slug) ?? null;
+          previousIcons.set(descriptor.slug, {
+            descriptor: previousDescriptor
+          });
+        }
+        Object.defineProperty(iconMap, descriptor.slug, {
+          configurable: true,
+          enumerable: true,
+          writable: true,
+          value: iconMap[descriptor.icon] ?? iconMap.personalization
+        });
+        applyGroupPlacements();
+        scanMounts();
+        refreshSettingsRoute();
+        let registered = true;
+        const unregister = () => {
+          if (!registered) return;
+          registered = false;
+          if (renderers.get(descriptor.slug) === renderer) {
+            const activeSlug = activeSettingsSlug();
+            renderers.delete(descriptor.slug);
+            for (const [element, record] of mounted) {
+              if (record.slug === descriptor.slug) cleanupMount(element, record);
+            }
+            for (let index = registry.length - 1; index >= 0; index -= 1) {
+              if (registry[index]?.slug === descriptor.slug) registry.splice(index, 1);
+            }
+            removeRoute(descriptor.slug);
+            removeLabel(descriptor.slug);
+            const previous = previousIcons.get(descriptor.slug);
+            if (previous) {
+              if (previous.descriptor) Object.defineProperty(iconMap, descriptor.slug, previous.descriptor);
+              else delete iconMap[descriptor.slug];
+              previousIcons.delete(descriptor.slug);
+            }
+            applyGroupPlacements();
+            if (activeSlug === descriptor.slug) {
+              navigateToSettings("/settings/general-settings", true);
+            } else {
+              refreshSettingsRoute();
+            }
+          }
+        };
+        return Object.freeze({
+          id: descriptor.id,
+          slug: descriptor.slug,
+          open() {
+            navigateToSettings("/settings/" + descriptor.slug);
+          },
+          unregister
+        });
+      },
+      cleanup() {
+        const activeSlug = activeSettingsSlug();
+        const wasCustomRoute = Boolean(activeSlug && descriptors.has(activeSlug));
+        if (wasCustomRoute) {
+          navigateToSettings("/settings/general-settings", true);
+        }
+        observer.disconnect();
+        restoreGroupMapInterceptor();
+        for (const [element, record] of mounted) cleanupMount(element, record);
+        renderers.clear();
+        for (const descriptor of descriptors.values()) {
+          removeRoute(descriptor.slug);
+          removeLabel(descriptor.slug);
+        }
+        applyGroupPlacements();
+        if (registry) {
+          if (registry.filter === registryFilter) {
+            if (originalRegistryFilterDescriptor) {
+              Object.defineProperty(registry, "filter", originalRegistryFilterDescriptor);
+            } else {
+              delete registry.filter;
+            }
+          }
+          for (let index = registry.length - 1; index >= 0; index -= 1) {
+            if (descriptors.has(registry[index]?.slug)) registry.splice(index, 1);
+          }
+        }
+        if (iconMap) {
+          for (const [slug, previous] of previousIcons) {
+            if (previous.descriptor) Object.defineProperty(iconMap, slug, previous.descriptor);
+            else delete iconMap[slug];
+          }
+        }
+        if (!wasCustomRoute) refreshSettingsRoute();
+        if (globalThis[globalKey] === adapter) delete globalThis[globalKey];
+      }
+    };
+    globalThis[globalKey] = adapter;
+
+    try {
+      const [appModule, visibilityModule] = await Promise.all([
+        import(configuration.appModuleUrl),
+        import(configuration.visibilityModuleUrl)
+      ]);
+      registry = Object.values(appModule).find((value) =>
+        Array.isArray(value)
+        && value.some((entry) => entry?.slug === "general-settings")
+        && value.some((entry) => entry?.slug === "personalization")
+      );
+      if (!registry) throw new Error("Codex settings registry unavailable");
+      navigationBus = Object.values(appModule).find((value) =>
+        value && typeof value === "object"
+        && value.handlers instanceof Map
+        && typeof value.dispatchHostMessage === "function"
+        && typeof value.deliverMessage === "function"
+      );
+      if (!navigationBus) throw new Error("Codex navigation bus unavailable");
+      const settingsRoute = findSettingsRouteElement();
+      settingsRouteChildren = settingsRoute?.props?.children;
+      if (!Array.isArray(settingsRouteChildren)) {
+        throw new Error("Codex settings route registry unavailable");
+      }
+      if (Object.isFrozen(settingsRouteChildren)) {
+        throw new Error("Codex settings route registry is immutable");
+      }
+      routeTemplate = flattenReactElements(settingsRouteChildren).find(
+        (candidate) => candidate?.props?.path === "*"
+      );
+      if (!routeTemplate?.type) {
+        throw new Error("Codex settings route component unavailable");
+      }
+      originalRegistryFilterDescriptor = Object.getOwnPropertyDescriptor(registry, "filter") ?? null;
+      registryFilter = function (callback, thisArg) {
+        const visible = Array.prototype.filter.call(this, callback, thisArg);
+        for (const descriptor of descriptors.values()) {
+          if (!renderers.has(descriptor.slug)) continue;
+          if (!visible.some((entry) => entry?.slug === descriptor.slug)) {
+            visible.push(registry.find((entry) => entry?.slug === descriptor.slug) ?? { slug: descriptor.slug });
+          }
+        }
+        return visible;
+      };
+      registry.filter = registryFilter;
+      if (registry.filter !== registryFilter) {
+        throw new Error("Codex settings registry is immutable");
+      }
+
+      iconMap = Object.values(visibilityModule).find((value) =>
+        value && typeof value === "object"
+        && typeof value.personalization === "function"
+        && typeof value["general-settings"] === "function"
+      );
+      if (!iconMap) throw new Error("Codex settings icon registry unavailable");
+      observer.observe(document.documentElement, { childList: true, subtree: true });
+      scanMounts();
+      return adapter;
+    } catch (error) {
+      adapter.cleanup();
+      throw error;
+    }
+  };
+
+  try {
+    settingsAdapter = await installSettingsAdapter(settingsAdapterConfiguration);
+  } catch (error) {
+    settingsAdapterError = error instanceof Error ? error.message : String(error);
+    console.error("Codex Tweaks settings adapter unavailable", error);
+  }
+
+  const createPackageCapabilities = (token, grants, packageID, registerCleanup) => {
+    const handles = new Map();
+    for (const [capabilityID, grant] of Object.entries(grants ?? {})) {
+      if (capabilityID === "network" && grant?.version === "1.0.0") {
+        handles.set(capabilityID, Object.freeze({
+          id: capabilityID,
+          version: grant.version,
+          request(parameters = {}) {
+            return invokeCapability(token, capabilityID, "request", parameters);
+          }
+        }));
+      }
+      if (
+        capabilityID === "ui.settings-section"
+        && grant?.version === "1.0.0"
+        && settingsAdapter
+      ) {
+        const declaredSections = Array.isArray(grant.permissions?.sections)
+          ? grant.permissions.sections
+          : [];
+        handles.set(capabilityID, Object.freeze({
+          id: capabilityID,
+          version: grant.version,
+          list() {
+            return declaredSections.map((section) => ({
+              id: section.id,
+              title: section.title,
+              slug: section.slug
+            }));
+          },
+          register(options) {
+            if (!options || typeof options !== "object") {
+              throw new TypeError("Settings section registration must be an object");
+            }
+            const sectionID = String(options.id ?? "").trim();
+            const mount = options.mount;
+            const registration = settingsAdapter.register(packageID, sectionID, mount);
+            registerCleanup(registration.unregister);
+            return registration;
+          }
+        }));
+      }
+    }
+    const normalizeCapabilityID = (capabilityID) => {
+      if (typeof capabilityID !== "string" || !capabilityID.trim()) {
+        throw new TypeError("Capability ID must be a non-empty string");
+      }
+      return capabilityID.trim();
+    };
+    return Object.freeze({
+      has(capabilityID) {
+        return handles.has(normalizeCapabilityID(capabilityID));
+      },
+      get(capabilityID) {
+        return handles.get(normalizeCapabilityID(capabilityID));
+      },
+      require(capabilityID) {
+        const normalizedID = normalizeCapabilityID(capabilityID);
+        const handle = handles.get(normalizedID);
+        if (!handle) {
+          throw new Error("Required capability unavailable: " + normalizedID);
+        }
+        return handle;
+      },
+      list() {
+        return [...handles.keys()];
+      }
+    });
+  };
 
   const cleanupPackageState = (state) => {
     if (!state || state.cleaned) return;
@@ -63,12 +680,38 @@ func InjectionScript(payload Payload, forceGeneration int) string {
 
   const runtime = {
     version,
+    bridgeSessionID,
+    settingsAdapterKey,
+    settingsAdapterReady: !settingsAdapterExpected || Boolean(settingsAdapter),
     packageErrors,
+    settleCapability(response) {
+      if (!response || typeof response.id !== "string") return false;
+      const pending = capabilityPending.get(response.id);
+      if (!pending) return false;
+      capabilityPending.delete(response.id);
+      clearTimeout(pending.timeout);
+      if (response.ok) {
+        pending.resolve(response.result);
+      } else {
+        pending.reject(capabilityError(
+          response.error?.message ?? "Capability request failed",
+          response.error?.code ?? "capability_error"
+        ));
+      }
+      return true;
+    },
     cleanup() {
       for (const state of [...packageStates.values()].reverse()) {
         cleanupPackageState(state);
       }
       packageStates.clear();
+      for (const pending of capabilityPending.values()) {
+        clearTimeout(pending.timeout);
+        pending.reject(capabilityError("Codex Tweaks runtime was cleaned up", "runtime_cleanup"));
+      }
+      capabilityPending.clear();
+      try { settingsAdapter?.cleanup?.(); } catch (_) {}
+      settingsAdapter = null;
       host.remove();
       if (globalThis[key] === runtime) delete globalThis[key];
     }
@@ -79,8 +722,8 @@ func InjectionScript(payload Payload, forceGeneration int) string {
 
 %s
 
-  return { status: "injected", version, packageErrors };
-})()`, JSONLiteral(effectiveVersion), strings.Join(setups, "\n"), strings.Join(executions, "\n"))
+  return { status: "injected", version, packageErrors, settingsAdapterError };
+})()`, JSONLiteral(effectiveVersion), JSONLiteral(bridgeSessionID), JSONLiteral(settingsAdapterConfiguration), JSONLiteral(capabilityBindingName), strings.Join(setups, "\n"), strings.Join(executions, "\n"))
 }
 
 func packageSetupScript(pkg CompiledPackage) string {
@@ -110,13 +753,18 @@ func packageSetupScript(pkg CompiledPackage) string {
   }`, JSONLiteral(pkg.ID), JSONLiteral(pkg.Name), JSONLiteral(pkg.Version), JSONLiteral(pkg.CSS))
 }
 
-func packageExecutionScript(pkg CompiledPackage) string {
+func packageExecutionScript(pkg CompiledPackage, capabilityToken string) string {
 	return fmt.Sprintf(`  {
     const packageID = %s;
     const packageName = %s;
     const packageVersion = %s;
-    const dependencyIDs = %s;
+    const dependencyIDs = %s ?? [];
+    const grantedCapabilities = %s;
+    const capabilityToken = %s;
     const state = packageStates.get(packageID);
+    const registerPackageCleanup = (callback) => {
+      if (typeof callback === "function") state.cleanupCallbacks.push(callback);
+    };
     const normalizeLibraryName = (name) => {
       if (typeof name !== "string" || !name.trim()) {
         throw new TypeError("Library name must be a non-empty string");
@@ -126,8 +774,14 @@ func packageExecutionScript(pkg CompiledPackage) string {
     const api = {
       packageID,
       version: packageVersion,
+      capabilities: createPackageCapabilities(
+        capabilityToken,
+        grantedCapabilities,
+        packageID,
+        registerPackageCleanup
+      ),
       registerCleanup(callback) {
-        if (typeof callback === "function") state.cleanupCallbacks.push(callback);
+        registerPackageCleanup(callback);
       },
       registerLibrary(name, value) {
         const normalizedName = normalizeLibraryName(name);
@@ -195,6 +849,7 @@ func packageExecutionScript(pkg CompiledPackage) string {
       version: packageVersion,
       root: state.root,
       api,
+      capabilities: api.capabilities,
       dependencies,
       onCleanup: api.registerCleanup
     };
@@ -227,5 +882,5 @@ func packageExecutionScript(pkg CompiledPackage) string {
         : String(error);
       packageErrors.push({ id: packageID, name: packageName, message });
     }
-  }`, JSONLiteral(pkg.ID), JSONLiteral(pkg.Name), JSONLiteral(pkg.Version), JSONLiteral(pkg.DependencyIDs), pkg.JavaScript)
+  }`, JSONLiteral(pkg.ID), JSONLiteral(pkg.Name), JSONLiteral(pkg.Version), JSONLiteral(pkg.DependencyIDs), JSONLiteral(pkg.Capabilities), JSONLiteral(capabilityToken), pkg.JavaScript)
 }

--- a/backend/internal/core/injection_test.go
+++ b/backend/internal/core/injection_test.go
@@ -34,3 +34,43 @@ func TestInjectionRuntimeAndForceContracts(t *testing.T) {
 		t.Fatal("cleanup contract changed")
 	}
 }
+
+func TestInjectionExposesGrantedCapabilitiesAndSettingsAdapter(t *testing.T) {
+	payload := Payload{Version: "capabilities", Packages: []CompiledPackage{{
+		ID: "sample", Name: "sample", Version: "1.0.0",
+		Capabilities: map[string]GrantedCapability{
+			NetworkCapabilityID: {Version: NetworkCapabilityVersion},
+			UISettingsSectionCapabilityID: {
+				Version:     UISettingsSectionCapabilityVersion,
+				Permissions: []byte(`{"sections":[{"id":"wallpaper","title":"随机背景","slug":"codex-tweaks-sample-wallpaper-12345678"}]}`),
+			},
+		},
+		JavaScript: `module.exports.activate = ({ capabilities }) => capabilities.require("network");`,
+	}}}
+	configuration := &SettingsAdapterConfiguration{
+		AppModuleURL:        "app://-/assets/app-initial-test.js",
+		VisibilityModuleURL: "app://-/assets/use-visible-settings-sections-test.js",
+		Sections: []RuntimeSettingsSection{{
+			PackageID: "sample",
+			UISettingsSectionPermission: UISettingsSectionPermission{
+				ID: "wallpaper", Title: "随机背景", Slug: "codex-tweaks-sample-wallpaper-12345678",
+			},
+		}},
+	}
+	script := injectionScriptWithCapabilities(
+		payload, 0, "bridge-session", map[string]string{"sample": "secret-token"}, configuration,
+	)
+	for _, expected := range []string{
+		`"bridge-session"`, `"secret-token"`, `"appModuleUrl"`,
+		"capabilities: createPackageCapabilities(", "ui.settings-section",
+		"registry.push({ slug: descriptor.slug })", "iconMap[descriptor.slug]",
+		"settingsRouteChildren.splice(", "dispatchHostMessage", "labelRegistry", "groupRegistry",
+		`key.startsWith("__reactFiber$")`, "settingsAdapter?.cleanup?.()",
+		"capabilityPendingLimit = 64",
+		"settingsAdapterReady",
+	} {
+		if !strings.Contains(script, expected) {
+			t.Fatalf("capability injection script missing %q", expected)
+		}
+	}
+}

--- a/backend/internal/core/model.go
+++ b/backend/internal/core/model.go
@@ -58,20 +58,27 @@ type PackageDependency struct {
 }
 
 type PackageConfiguration struct {
-	APIVersion          int                          `json:"apiVersion"`
-	Entry               string                       `json:"entry"`
-	Priority            int                          `json:"priority"`
-	PackageDependencies map[string]PackageDependency `json:"packageDependencies"`
+	APIVersion          int                              `json:"apiVersion"`
+	Entry               string                           `json:"entry"`
+	Priority            int                              `json:"priority"`
+	PackageDependencies map[string]PackageDependency     `json:"packageDependencies"`
+	Capabilities        map[string]CapabilityRequirement `json:"capabilities,omitempty"`
 }
 
 func (c *PackageConfiguration) UnmarshalJSON(data []byte) error {
 	type configuration PackageConfiguration
-	value := configuration{APIVersion: APIVersion, PackageDependencies: map[string]PackageDependency{}}
+	value := configuration{
+		APIVersion: APIVersion, PackageDependencies: map[string]PackageDependency{},
+		Capabilities: map[string]CapabilityRequirement{},
+	}
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
 	if value.PackageDependencies == nil {
 		value.PackageDependencies = map[string]PackageDependency{}
+	}
+	if value.Capabilities == nil {
+		value.Capabilities = map[string]CapabilityRequirement{}
 	}
 	*c = PackageConfiguration(value)
 	return nil
@@ -121,26 +128,33 @@ func (t *CodableTime) UnmarshalJSON(data []byte) error {
 }
 
 type PackageBuildRecord struct {
-	PackageID             string            `json:"packageID"`
-	PackageVersion        string            `json:"packageVersion"`
-	PackageDependencies   map[string]string `json:"packageDependencies"`
-	SourceFingerprint     string            `json:"sourceFingerprint"`
-	DependencyFingerprint string            `json:"dependencyFingerprint"`
-	CompilerVersion       string            `json:"compilerVersion"`
-	NodeVersion           string            `json:"nodeVersion"`
-	BuildDirectoryName    string            `json:"buildDirectoryName"`
-	HasCSS                bool              `json:"hasCSS"`
-	BuiltAt               CodableTime       `json:"builtAt"`
+	PackageID             string                           `json:"packageID"`
+	PackageVersion        string                           `json:"packageVersion"`
+	PackageDependencies   map[string]string                `json:"packageDependencies"`
+	Capabilities          map[string]CapabilityRequirement `json:"capabilities,omitempty"`
+	SourceFingerprint     string                           `json:"sourceFingerprint"`
+	DependencyFingerprint string                           `json:"dependencyFingerprint"`
+	CompilerVersion       string                           `json:"compilerVersion"`
+	NodeVersion           string                           `json:"nodeVersion"`
+	BuildDirectoryName    string                           `json:"buildDirectoryName"`
+	HasCSS                bool                             `json:"hasCSS"`
+	BuiltAt               CodableTime                      `json:"builtAt"`
 }
 
 func (r *PackageBuildRecord) UnmarshalJSON(data []byte) error {
 	type record PackageBuildRecord
-	value := record{PackageDependencies: map[string]string{}}
+	value := record{
+		PackageDependencies: map[string]string{},
+		Capabilities:        map[string]CapabilityRequirement{},
+	}
 	if err := json.Unmarshal(data, &value); err != nil {
 		return err
 	}
 	if value.PackageDependencies == nil {
 		value.PackageDependencies = map[string]string{}
+	}
+	if value.Capabilities == nil {
+		value.Capabilities = map[string]CapabilityRequirement{}
 	}
 	*r = PackageBuildRecord(value)
 	return nil
@@ -364,13 +378,14 @@ func ReconcileEnablement(discovered, known, disabled map[string]bool, hasKnownBa
 }
 
 type CompiledPackage struct {
-	ID               string   `json:"id"`
-	Name             string   `json:"name"`
-	Version          string   `json:"version"`
-	BuildFingerprint string   `json:"buildFingerprint"`
-	DependencyIDs    []string `json:"dependencyIDs"`
-	CSS              string   `json:"css"`
-	JavaScript       string   `json:"javascript"`
+	ID               string                       `json:"id"`
+	Name             string                       `json:"name"`
+	Version          string                       `json:"version"`
+	BuildFingerprint string                       `json:"buildFingerprint"`
+	DependencyIDs    []string                     `json:"dependencyIDs"`
+	Capabilities     map[string]GrantedCapability `json:"capabilities,omitempty"`
+	CSS              string                       `json:"css"`
+	JavaScript       string                       `json:"javascript"`
 }
 
 type Payload struct {

--- a/backend/internal/core/store.go
+++ b/backend/internal/core/store.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"hash"
@@ -189,7 +190,7 @@ func (s *Store) InspectPackage(directory string, origin PackageOrigin, priorityO
 	if expectedPackageID != "" && manifest.Name != expectedPackageID {
 		return invalid(fmt.Errorf("远程功能包标识不匹配：期望 %s，实际为 %s。", expectedPackageID, manifest.Name))
 	}
-	sourceFingerprint, err := fingerprintPackage(directory)
+	sourceFingerprint, err := fingerprintPackage(manifest, directory)
 	if err != nil {
 		return invalid(err)
 	}
@@ -236,6 +237,9 @@ func validateManifest(manifest PackageManifest, packageDirectory string) error {
 			}
 		}
 	}
+	if _, err := ResolveCapabilityRequirements(manifest.CodexTweaks.Capabilities); err != nil {
+		return err
+	}
 	root, err := filepath.EvalSymlinks(packageDirectory)
 	if err != nil {
 		return fmt.Errorf("入口文件不存在或超出包目录：%s", manifest.CodexTweaks.Entry)
@@ -251,7 +255,7 @@ func validateManifest(manifest PackageManifest, packageDirectory string) error {
 	return nil
 }
 
-func fingerprintPackage(packageDirectory string) (string, error) {
+func fingerprintPackage(manifest PackageManifest, packageDirectory string) (string, error) {
 	type sourceFile struct{ relative, path string }
 	files := []sourceFile{}
 	err := filepath.WalkDir(packageDirectory, func(path string, entry fs.DirEntry, walkErr error) error {
@@ -288,6 +292,14 @@ func fingerprintPackage(packageDirectory string) (string, error) {
 		state.Update([]byte(file.relative))
 		state.Separator()
 		state.Update(contents)
+		state.Separator()
+	}
+	if len(manifest.CodexTweaks.Capabilities) > 0 {
+		capabilities, err := json.Marshal(manifest.CodexTweaks.Capabilities)
+		if err != nil {
+			return "", err
+		}
+		state.Update(capabilities)
 		state.Separator()
 	}
 	return state.Value(), nil
@@ -455,15 +467,24 @@ func (s *Store) LoadPayload(packages []Package, disabledPackageIDs map[string]bo
 				continue
 			}
 		}
+		capabilities, err := resolvePackageCapabilities(pkg.ID, pkg.ActiveBuild.Record.Capabilities)
+		if err != nil {
+			errorsByPackage[pkg.ID] = err.Error()
+			continue
+		}
 		compiled = append(compiled, CompiledPackage{
 			ID: pkg.ID, Name: pkg.Manifest.Name, Version: pkg.ActiveBuild.Record.PackageVersion,
 			BuildFingerprint: pkg.ActiveBuild.Record.SourceFingerprint + "-" + pkg.ActiveBuild.Record.DependencyFingerprint + "-" + pkg.ActiveBuild.Record.CompilerVersion,
-			DependencyIDs:    sortedStringKeys(pkg.ActiveBuild.Record.PackageDependencies), CSS: string(css), JavaScript: string(javascript),
+			DependencyIDs:    sortedStringKeys(pkg.ActiveBuild.Record.PackageDependencies), Capabilities: capabilities,
+			CSS: string(css), JavaScript: string(javascript),
 		})
 	}
 	materials := make([]string, 0, len(compiled))
 	for _, pkg := range compiled {
-		materials = append(materials, strings.Join([]string{pkg.ID, pkg.Version, pkg.BuildFingerprint, pkg.CSS, pkg.JavaScript}, "\x00"))
+		capabilities, _ := json.Marshal(pkg.Capabilities)
+		materials = append(materials, strings.Join([]string{
+			pkg.ID, pkg.Version, pkg.BuildFingerprint, string(capabilities), pkg.CSS, pkg.JavaScript,
+		}, "\x00"))
 	}
 	return PayloadLoadResult{Payload: Payload{Packages: compiled, Version: FingerprintString(strings.Join(materials, "\x00"))}, PackageErrors: errorsByPackage}
 }

--- a/backend/internal/core/store_test.go
+++ b/backend/internal/core/store_test.go
@@ -115,6 +115,62 @@ func TestStorePriorityOverrideIsSeparateAndNormalized(t *testing.T) {
 	}
 }
 
+func TestStoreCarriesCapabilitiesWithoutChangingPackageAPIVersion(t *testing.T) {
+	store, _ := newTestStore(t)
+	directory := makeStorePackage(t, store, "capable", "capable", "1.0.0", 0, nil, "")
+	manifest := PackageManifest{}
+	manifestPath := filepath.Join(directory, "package.json")
+	if err := readJSON(manifestPath, &manifest); err != nil {
+		t.Fatal(err)
+	}
+	manifest.CodexTweaks.Capabilities = map[string]CapabilityRequirement{
+		NetworkCapabilityID: {
+			Version:     "^1.0.0",
+			Permissions: json.RawMessage(`{"origins":["https://example.com"]}`),
+		},
+	}
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packages, err := store.LoadPackages()
+	if err != nil || len(packages) != 1 || packages[0].ValidationError != nil {
+		t.Fatalf("capability manifest failed: %v %#v", err, packages)
+	}
+	if packages[0].Manifest.CodexTweaks.APIVersion != APIVersion {
+		t.Fatalf("package API version changed: %d", packages[0].Manifest.CodexTweaks.APIVersion)
+	}
+	activateTestBuild(t, store, packages[0], "capable-js", "")
+	packages, _ = store.LoadPackages()
+	payload := store.LoadPayload(packages, map[string]bool{})
+	grant, ok := payload.Payload.Packages[0].Capabilities[NetworkCapabilityID]
+	if !ok || grant.Version != NetworkCapabilityVersion {
+		t.Fatalf("capability grant missing from payload: %#v", payload)
+	}
+
+	initialFingerprint := *packages[0].SourceFingerprint
+	initialDependencyFingerprint := *packages[0].DependencyFingerprint
+	manifest.CodexTweaks.Capabilities[NetworkCapabilityID] = CapabilityRequirement{
+		Version:     "^1.0.0",
+		Permissions: json.RawMessage(`{"origins":["https://changed.example"]}`),
+	}
+	data, _ = json.MarshalIndent(manifest, "", "  ")
+	if err := os.WriteFile(manifestPath, data, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	packages, _ = store.LoadPackages()
+	if *packages[0].SourceFingerprint == initialFingerprint ||
+		packages[0].BuildDisposition(CompilerVersion) != BuildSourceChanged {
+		t.Fatalf("capability change did not invalidate build: %#v", packages[0])
+	}
+	if *packages[0].DependencyFingerprint != initialDependencyFingerprint {
+		t.Fatalf("capability change was classified as a dependency update: %#v", packages[0])
+	}
+}
+
 func newTestStore(t *testing.T) (*Store, string) {
 	t.Helper()
 	root := t.TempDir()
@@ -172,7 +228,7 @@ func activateTestBuild(t *testing.T, store *Store, pkg Package, javascript, css 
 			t.Fatal(err)
 		}
 	}
-	record := PackageBuildRecord{PackageID: pkg.ID, PackageVersion: pkg.Manifest.Version, PackageDependencies: map[string]string{}, SourceFingerprint: *pkg.SourceFingerprint, DependencyFingerprint: *pkg.DependencyFingerprint, CompilerVersion: CompilerVersion, NodeVersion: "v24", BuildDirectoryName: "test-build", HasCSS: css != "", BuiltAt: NewCodableTime(time.Now())}
+	record := PackageBuildRecord{PackageID: pkg.ID, PackageVersion: pkg.Manifest.Version, PackageDependencies: map[string]string{}, Capabilities: cloneCapabilityRequirements(pkg.Manifest.CodexTweaks.Capabilities), SourceFingerprint: *pkg.SourceFingerprint, DependencyFingerprint: *pkg.DependencyFingerprint, CompilerVersion: CompilerVersion, NodeVersion: "v24", BuildDirectoryName: "test-build", HasCSS: css != "", BuiltAt: NewCodableTime(time.Now())}
 	if err := store.ActivateBuild(record); err != nil {
 		t.Fatal(err)
 	}

--- a/backend/internal/rpc/server_test.go
+++ b/backend/internal/rpc/server_test.go
@@ -48,7 +48,8 @@ func TestServerInitializesControllerWithoutBackgroundSideEffects(t *testing.T) {
 	}
 	input := strings.NewReader(
 		string(initializeRequest) + "\n" +
-			"{\"id\":2,\"method\":\"shutdown\"}\n",
+			"{\"id\":2,\"method\":\"getState\"}\n" +
+			"{\"id\":3,\"method\":\"shutdown\"}\n",
 	)
 	var output bytes.Buffer
 	server := NewServerWithDependencies(
@@ -67,6 +68,13 @@ func TestServerInitializesControllerWithoutBackgroundSideEffects(t *testing.T) {
 		} `json:"result"`
 	}
 	foundInitialize := false
+	var state struct {
+		ID     int `json:"id"`
+		Result struct {
+			AvailableCapabilities []core.CapabilityDescriptor `json:"availableCapabilities"`
+		} `json:"result"`
+	}
+	foundState := false
 	for _, line := range strings.Split(strings.TrimSpace(output.String()), "\n") {
 		var header struct {
 			ID *int `json:"id"`
@@ -80,9 +88,19 @@ func TestServerInitializesControllerWithoutBackgroundSideEffects(t *testing.T) {
 			}
 			foundInitialize = true
 		}
+		if header.ID != nil && *header.ID == 2 {
+			if err := json.Unmarshal([]byte(line), &state); err != nil {
+				t.Fatalf("decode getState: %v", err)
+			}
+			foundState = true
+		}
 	}
 	if !foundInitialize || initialize.Result.ProtocolVersion != core.ProtocolVersion {
 		t.Fatalf("initialize response not found in %q", output.String())
+	}
+	if !foundState || len(state.Result.AvailableCapabilities) == 0 ||
+		state.Result.AvailableCapabilities[0].Usage.RuntimeExample == "" {
+		t.Fatalf("getState did not expose usable availableCapabilities: %q", output.String())
 	}
 }
 

--- a/windows/CodexTweaks.Windows/Models/BackendModels.cs
+++ b/windows/CodexTweaks.Windows/Models/BackendModels.cs
@@ -195,6 +195,150 @@ internal sealed class BackendUpdateSnapshot
     public bool LatestVersionIsSkipped { get; init; }
 }
 
+internal sealed class CapabilityUsageDescriptor
+{
+    [JsonPropertyName("useWhen")]
+    public List<string> UseWhen { get; init; } = [];
+
+    [JsonPropertyName("constraints")]
+    public List<string> Constraints { get; init; } = [];
+
+    [JsonPropertyName("manifestExample")]
+    public string ManifestExample { get; init; } = string.Empty;
+
+    [JsonPropertyName("runtimeExample")]
+    public string RuntimeExample { get; init; } = string.Empty;
+}
+
+internal sealed class CapabilityManifestDescriptor
+{
+    [JsonPropertyName("requirementJSONPointer")]
+    public string RequirementJsonPointer { get; init; } = string.Empty;
+
+    [JsonPropertyName("fields")]
+    public List<CapabilityFieldDescriptor> Fields { get; init; } = [];
+}
+
+internal sealed class CapabilityRuntimeDescriptor
+{
+    [JsonPropertyName("scope")]
+    public string Scope { get; init; } = string.Empty;
+
+    [JsonPropertyName("requiredAccess")]
+    public string RequiredAccess { get; init; } = string.Empty;
+
+    [JsonPropertyName("optionalAccess")]
+    public string OptionalAccess { get; init; } = string.Empty;
+
+    [JsonPropertyName("properties")]
+    public List<CapabilityFieldDescriptor> Properties { get; init; } = [];
+
+    [JsonPropertyName("methods")]
+    public List<CapabilityMethodDescriptor> Methods { get; init; } = [];
+}
+
+internal sealed class CapabilityMethodDescriptor
+{
+    [JsonPropertyName("name")]
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("async")]
+    public bool Async { get; init; }
+
+    [JsonPropertyName("signature")]
+    public string Signature { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("inputs")]
+    public List<CapabilityFieldDescriptor> Inputs { get; init; } = [];
+
+    [JsonPropertyName("outputs")]
+    public List<CapabilityFieldDescriptor> Outputs { get; init; } = [];
+
+    [JsonPropertyName("errors")]
+    public List<CapabilityErrorDescriptor> Errors { get; init; } = [];
+}
+
+internal sealed class CapabilityFieldDescriptor
+{
+    [JsonPropertyName("path")]
+    public string Path { get; init; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; init; } = string.Empty;
+
+    [JsonPropertyName("itemType")]
+    public string? ItemType { get; init; }
+
+    [JsonPropertyName("format")]
+    public string? Format { get; init; }
+
+    [JsonPropertyName("required")]
+    public bool Required { get; init; }
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+
+    [JsonPropertyName("values")]
+    public List<string>? Values { get; init; }
+
+    [JsonPropertyName("defaultJSON")]
+    public string? DefaultJson { get; init; }
+
+    [JsonPropertyName("minimum")]
+    public int? Minimum { get; init; }
+
+    [JsonPropertyName("maximum")]
+    public int? Maximum { get; init; }
+
+    [JsonPropertyName("minimumItems")]
+    public int? MinimumItems { get; init; }
+
+    [JsonPropertyName("maximumItems")]
+    public int? MaximumItems { get; init; }
+
+    [JsonPropertyName("minimumLength")]
+    public int? MinimumLength { get; init; }
+
+    [JsonPropertyName("maximumLength")]
+    public int? MaximumLength { get; init; }
+}
+
+internal sealed class CapabilityErrorDescriptor
+{
+    [JsonPropertyName("code")]
+    public string Code { get; init; } = string.Empty;
+
+    [JsonPropertyName("description")]
+    public string Description { get; init; } = string.Empty;
+}
+
+internal sealed class CapabilityDescriptor
+{
+    [JsonPropertyName("descriptorVersion")]
+    public int DescriptorVersion { get; init; }
+
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = string.Empty;
+
+    [JsonPropertyName("version")]
+    public string Version { get; init; } = string.Empty;
+
+    [JsonPropertyName("summary")]
+    public string Summary { get; init; } = string.Empty;
+
+    [JsonPropertyName("usage")]
+    public CapabilityUsageDescriptor Usage { get; init; } = new();
+
+    [JsonPropertyName("manifest")]
+    public CapabilityManifestDescriptor Manifest { get; init; } = new();
+
+    [JsonPropertyName("runtime")]
+    public CapabilityRuntimeDescriptor Runtime { get; init; } = new();
+}
+
 internal sealed class BackendAppSnapshot
 {
     [JsonPropertyName("protocolVersion")]
@@ -211,6 +355,9 @@ internal sealed class BackendAppSnapshot
 
     [JsonPropertyName("developerMode")]
     public bool DeveloperMode { get; init; }
+
+    [JsonPropertyName("availableCapabilities")]
+    public List<CapabilityDescriptor> AvailableCapabilities { get; init; } = [];
 
     [JsonPropertyName("packages")]
     public List<PackageView> Packages { get; init; } = [];


### PR DESCRIPTION
## 变更内容

- 为功能包清单新增独立版本化的 host capabilities 声明、校验、构建记录与运行时授权。
- 提供受限的 network 与 UI settings 能力，并通过 CDP bridge 注入到每个已授权功能包。
- 在 AppSnapshot 中发布可机读能力描述，补齐 Swift、C# 协议 DTO 与解码测试。
- 更新功能包开发 Skill，明确以宿主返回的能力目录为唯一事实来源。

## 验证

- `mise run generate`：通过，生成文件无漂移。
- `cd backend && go test -race ./internal/core ./internal/rpc`：通过。
- `cd backend && go vet ./...`：通过。
- `cd backend && GOOS=windows GOARCH=amd64 go build ./...`：通过。
- `cd backend && GOOS=windows GOARCH=arm64 go build ./...`：通过。
- `mise run verify`：通过（含 workflow lint、Go race/vet、Swift 测试、macOS Release 构建与生成漂移检查）。
- `git diff --cached --check` / `git diff --check`：通过。

Windows WinUI 3 原生 build/package/verify 以本 PR 的 Windows CI 为准。