### PR TITLE
fix: 修复 Windows Node 授权与运行窗口

### DIFF
--- a/app/Sources/MainWindowView.swift
+++ b/app/Sources/MainWindowView.swift
@@ -453,7 +453,10 @@ private struct TweakPackagesView: View {
                 HStack(spacing: 8) {
                     if package.availableActions.authorizeNode {
                         Button(model.text(.packagesNodeAuthorizationAllow)) {
-                            model.authorizeNodePackage(package)
+                            model.authorizeNodePackage(
+                                package,
+                                enableAfterAuthorization: !model.isTweakPackageEnabled(package)
+                            )
                         }
                     }
 

--- a/backend/internal/core/command_windows_test.go
+++ b/backend/internal/core/command_windows_test.go
@@ -3,6 +3,7 @@
 package core
 
 import (
+	"context"
 	"os/exec"
 	"testing"
 )
@@ -10,6 +11,16 @@ import (
 func TestWindowsCommandsNeverCreateAVisibleConsole(t *testing.T) {
 	command := exec.Command("cmd.exe", "/D", "/C", "exit", "0")
 	configureCommand(command)
+	assertCommandHasNoVisibleConsole(t, command)
+}
+
+func TestWindowsNodeRuntimeNeverCreatesAVisibleConsole(t *testing.T) {
+	command := newNodeRuntimeCommand(context.Background(), "node.exe", "-e", "")
+	assertCommandHasNoVisibleConsole(t, command)
+}
+
+func assertCommandHasNoVisibleConsole(t *testing.T, command *exec.Cmd) {
+	t.Helper()
 	if command.SysProcAttr == nil {
 		t.Fatal("configureCommand did not set Windows process attributes")
 	}

--- a/backend/internal/core/controller.go
+++ b/backend/internal/core/controller.go
@@ -258,7 +258,7 @@ func (c *Controller) Snapshot() AppSnapshot {
 			EnableDependencies:         view.CanEnableDependencies && !deletingAnyPackage,
 			UpdateManagedPackage:       hasRemoteUpdate && remoteUpdate.Installable() && c.gitEnvironment != nil && !c.installingPackageIDs[pkg.ID] && !deletingAnyPackage,
 			Build:                      view.ValidationError == nil && view.BuildRequestKey != nil && c.nodeEnvironment != nil && !c.buildingPackageIDs[pkg.ID] && !deletingAnyPackage,
-			AuthorizeNode:              view.Node != nil && view.Node.AuthorizationID != "" && !view.Node.Authorized && !c.disabledPackageIDs[pkg.ID] && !deletingAnyPackage,
+			AuthorizeNode:              view.Node != nil && view.Node.AuthorizationID != "" && !view.Node.Authorized && !deletingAnyPackage,
 		}
 		view.Presentation = c.packagePresentation(view, presentationText)
 		packageViews = append(packageViews, view)

--- a/backend/internal/core/controller_test.go
+++ b/backend/internal/core/controller_test.go
@@ -293,6 +293,9 @@ func TestControllerRevokesExplicitNodeAuthorizationOnDisableAndRevisionChange(t 
 	if node == nil || node.AuthorizationID == "" || node.Authorized {
 		t.Fatalf("unexpected initial Node authorization state: %#v", node)
 	}
+	if !snapshot.Packages[0].AvailableActions.AuthorizeNode {
+		t.Fatal("disabled Node package did not expose the authorization flow")
+	}
 	if err := controller.AuthorizeNodePackage("node-lifecycle", node.AuthorizationID); err == nil {
 		t.Fatal("disabled Node package accepted an authorization")
 	}

--- a/backend/internal/core/node_runtime.go
+++ b/backend/internal/core/node_runtime.go
@@ -387,7 +387,7 @@ func startNodeRuntimeProcess(
 		return nil, errors.New("Node 编译产物不存在。")
 	}
 	processContext, cancel := context.WithCancel(ctx)
-	command := exec.CommandContext(processContext, environment.NodePath, "-e", nodeRuntimeRunnerSource,
+	command := newNodeRuntimeCommand(processContext, environment.NodePath, "-e", nodeRuntimeRunnerSource,
 		pkg.ActiveBuild.NodeJavaScriptPath(), pkg.Directory, dataDirectory)
 	command.Dir = pkg.Directory
 	environmentValues := environmentMap()
@@ -443,6 +443,12 @@ func startNodeRuntimeProcess(
 		process.stop()
 		return nil, ctx.Err()
 	}
+}
+
+func newNodeRuntimeCommand(ctx context.Context, executable string, arguments ...string) *exec.Cmd {
+	command := exec.CommandContext(ctx, executable, arguments...)
+	configureCommand(command)
+	return command
 }
 
 func (p *nodeRuntimeProcess) readStdout(reader io.Reader) {

--- a/windows/CodexTweaks.Windows/Pages/PackagesPage.xaml.cs
+++ b/windows/CodexTweaks.Windows/Pages/PackagesPage.xaml.cs
@@ -461,8 +461,7 @@ public sealed partial class PackagesPage : Page
 
     private async void PackageToggle_Toggled(object sender, RoutedEventArgs e)
     {
-        if (_rendering
-            || sender is not ToggleSwitch { DataContext: PackageRowViewModel row } toggle
+        if (sender is not ToggleSwitch { DataContext: PackageRowViewModel row } toggle
             || _snapshot is null)
         {
             return;
@@ -475,35 +474,43 @@ public sealed partial class PackagesPage : Page
 
         var requestedEnabled = toggle.IsOn;
         row.BeginEnablementChange(requestedEnabled);
-        string? error = null;
         var requiresNodeAuthorization = requestedEnabled
             && row.Package.Node is not null
             && !row.Package.Node.ExplicitlyAuthorized
             && !_snapshot.DeveloperAllowUnknownNode;
-        if (requiresNodeAuthorization)
-        {
-            if (!await ConfirmNodeAuthorizationAsync(row.Package))
-            {
-                error = "cancelled";
-            }
-        }
-        if (error is null)
-        {
-            error = await Host.RunBackendAsync(
+        var error = requiresNodeAuthorization
+            ? await AuthorizeNodePackageAsync(row, enableAfterAuthorization: true)
+            : await Host.RunBackendAsync(
                 "setPackageEnabled",
                 new { packageID = row.Id, enabled = requestedEnabled });
-        }
-        if (error is null && requiresNodeAuthorization)
-        {
-            error = await Host.RunBackendAsync(
-                "authorizeNodePackage",
-                new
-                {
-                    packageID = row.Id,
-                    authorizationID = row.Package.Node!.AuthorizationId,
-                });
-        }
         row.EndEnablementChange(error is null);
+    }
+
+    private async Task<string?> AuthorizeNodePackageAsync(
+        PackageRowViewModel row,
+        bool enableAfterAuthorization)
+    {
+        if (!await ConfirmNodeAuthorizationAsync(row.Package))
+        {
+            return "cancelled";
+        }
+        if (enableAfterAuthorization)
+        {
+            var enableError = await Host.RunBackendAsync(
+                "setPackageEnabled",
+                new { packageID = row.Id, enabled = true });
+            if (enableError is not null)
+            {
+                return enableError;
+            }
+        }
+        return await Host.RunBackendAsync(
+            "authorizeNodePackage",
+            new
+            {
+                packageID = row.Id,
+                authorizationID = row.Package.Node!.AuthorizationId,
+            });
     }
 
     private async Task<bool> ConfirmNodeAuthorizationAsync(PackageView package)
@@ -553,17 +560,13 @@ public sealed partial class PackagesPage : Page
     private async void AuthorizeNodeButton_Click(object sender, RoutedEventArgs e)
     {
         if (sender is not Button { DataContext: PackageRowViewModel row }
-            || !await ConfirmNodeAuthorizationAsync(row.Package))
+            || _snapshot is null)
         {
             return;
         }
-        await Host.RunBackendAsync(
-            "authorizeNodePackage",
-            new
-            {
-                packageID = row.Id,
-                authorizationID = row.Package.Node!.AuthorizationId,
-            });
+        await AuthorizeNodePackageAsync(
+            row,
+            enableAfterAuthorization: _snapshot.DisabledPackageIds.Contains(row.Id));
     }
 
     private async void PriorityTextBox_KeyDown(object sender, KeyRoutedEventArgs e)


### PR DESCRIPTION
## 变更内容

- 允许被 Node 授权阻止且当前禁用的功能包显示授权入口，并在用户确认作者说明后按正确顺序启用与授权当前版本
- 统一 macOS 与 Windows 的授权后启用语义，避免禁用状态下直接调用授权被后端拒绝
- Windows Node runtime 启动时复用无前台控制台进程配置，并补充 Windows 回归测试

## 验证

- `mise run verify`（通过：workflow lint、ShellCheck、Go vet/race tests、Windows amd64/arm64 Go builds、Presentation Contract、Swift tests、macOS Release build、generated drift）
- Parallels Windows 11 ARM64 VM：`scripts/build-windows.ps1 -Version 3.2.1 -BuildNumber 1`（x64/ARM64 通过）
- Parallels Windows 11 ARM64 VM：`scripts/package-windows.ps1 -Version 3.2.1 -Channel stable`（x64/ARM64 通过）
- Parallels Windows 11 ARM64 VM：`scripts/verify-windows.ps1 -Version 3.2.1 -Channel stable -RequirePackages`（通过；ARM64 原生 RPC smoke，x64 PE/包验证）
- 在 VM 中实际启动 ARM64 WinUI，未出现伴随前台命令行窗口；Parallels 自动化点击未能完成授权对话框交互，因此该部分等待远程 Windows CI 与后续人工交互证据
- `git diff --check`（通过）