### PR TITLE
feat: 支持 Git 功能包跟随仓库主分支

### DIFF
--- a/Skills/develop-codex-tweaks-package/SKILL.md
+++ b/Skills/develop-codex-tweaks-package/SKILL.md
@@ -280,7 +280,7 @@ Declare Codex Tweaks package dependencies under `codexTweaks.packageDependencies
 - Dependencies activate before dependents. The app blocks dependents when a dependency is missing, disabled, invalid, incompatible, unauthorized, or cyclic.
 - Supported version requirements are exact SemVer, `^`, `~`, comparisons, and `x` or `*` wildcards.
 - Omitting `source` means local-only. Supplying `source` declares explicit Git acquisition metadata; the app confirms, locks, installs, and updates it.
-- Supported selectors are `branch`, `latestSemverTag`, `tag`, `githubLatestRelease`, `githubRelease`, and `commit`. Required selector values must be explicit.
+- Supported selectors are `defaultBranch`, `branch`, `latestSemverTag`, `tag`, `githubLatestRelease`, `githubRelease`, and `commit`. `defaultBranch` follows the repository's remote HEAD; required selector values must be explicit.
 - Do not clone, download, self-update, or invent repository URLs from runtime code.
 - Package dependencies provide activation ordering and exported libraries, not compile-time source imports. Put shared compile-time code in an npm package.
 

--- a/app/Sources/GeneratedPresentationContract.swift
+++ b/app/Sources/GeneratedPresentationContract.swift
@@ -231,6 +231,7 @@ enum PresentationTextKey: String, CaseIterable, Sendable {
     case selectorBranchValue = "selector.branchValue"
     case selectorCommit = "selector.commit"
     case selectorCommitValue = "selector.commitValue"
+    case selectorDefaultBranch = "selector.defaultBranch"
     case selectorGithubLatestRelease = "selector.githubLatestRelease"
     case selectorGithubRelease = "selector.githubRelease"
     case selectorGithubReleaseValue = "selector.githubReleaseValue"
@@ -590,6 +591,7 @@ enum GeneratedPresentationDefaults {
         .selectorBranchValue: "分支名称",
         .selectorCommit: "指定 Commit",
         .selectorCommitValue: "Commit SHA",
+        .selectorDefaultBranch: "仓库主分支",
         .selectorGithubLatestRelease: "GitHub 最新 Release",
         .selectorGithubRelease: "指定 GitHub Release",
         .selectorGithubReleaseValue: "Release 的 Tag",

--- a/app/Sources/MainWindowView.swift
+++ b/app/Sources/MainWindowView.swift
@@ -1097,7 +1097,7 @@ private struct GitPackageInstallView: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var model: AppModel
     @State private var repositoryURL = ""
-    @State private var selectorType: TweakPackageRemoteSelectorType = .branch
+    @State private var selectorType: TweakPackageRemoteSelectorType = .defaultBranch
     @State private var selectorValue = ""
 
     var body: some View {
@@ -1169,9 +1169,6 @@ private struct GitPackageInstallView: View {
         .frame(minHeight: 420)
         .onAppear {
             model.clearRemoteOperationFeedback()
-            if selectorValue.isEmpty {
-                selectorValue = model.text(.selectorBranchDefault)
-            }
         }
         .onChange(of: selectorType) { type in
             selectorValue = type == .branch ? model.text(.selectorBranchDefault) : ""

--- a/app/Sources/TweakPackageModels.swift
+++ b/app/Sources/TweakPackageModels.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum TweakPackageRemoteSelectorType: String, Codable, CaseIterable, Identifiable, Sendable {
+    case defaultBranch
     case branch
     case latestSemverTag
     case tag
@@ -12,6 +13,7 @@ enum TweakPackageRemoteSelectorType: String, Codable, CaseIterable, Identifiable
 
     var titleKey: PresentationTextKey {
         switch self {
+        case .defaultBranch: return .selectorDefaultBranch
         case .branch: return .selectorBranch
         case .latestSemverTag: return .selectorLatestSemverTag
         case .tag: return .selectorTag
@@ -27,7 +29,7 @@ enum TweakPackageRemoteSelectorType: String, Codable, CaseIterable, Identifiable
         case .tag: return .selectorTagValue
         case .githubRelease: return .selectorGithubReleaseValue
         case .commit: return .selectorCommitValue
-        case .latestSemverTag, .githubLatestRelease: return nil
+        case .defaultBranch, .latestSemverTag, .githubLatestRelease: return nil
         }
     }
 

--- a/backend/internal/core/model.go
+++ b/backend/internal/core/model.go
@@ -20,6 +20,7 @@ const (
 type RemoteSelectorType string
 
 const (
+	SelectorDefaultBranch       RemoteSelectorType = "defaultBranch"
 	SelectorBranch              RemoteSelectorType = "branch"
 	SelectorLatestSemverTag     RemoteSelectorType = "latestSemverTag"
 	SelectorTag                 RemoteSelectorType = "tag"

--- a/backend/internal/core/presentation.go
+++ b/backend/internal/core/presentation.go
@@ -445,6 +445,7 @@ func PresentationText() map[string]string {
 		"remote.install":                              "安装",
 		"remote.close":                                "关闭",
 		"remote.validationDetail":                     "安装会校验 package.json、API 版本、SemVer、入口、包依赖与 npm 锁文件。通过后新包默认保持停用；有 Node.js 时会继续下载锁定依赖并编译，但不会自动启用。",
+		"selector.defaultBranch":                      "仓库主分支",
 		"selector.branch":                             "指定分支",
 		"selector.latestSemverTag":                    "最新 SemVer Tag",
 		"selector.tag":                                "指定 Tag",

--- a/backend/internal/core/remote.go
+++ b/backend/internal/core/remote.go
@@ -474,6 +474,17 @@ func (m *RemoteManager) resolve(ctx context.Context, source PackageSource, requi
 		return RemoteResolution{}, errors.New("没有找到可用的 Git。")
 	}
 	switch source.Selector.Type {
+	case SelectorDefaultBranch:
+		result, err := m.gitCommand(ctx, *git, []string{"ls-remote", "--symref", source.URL, "HEAD"})
+		if err != nil {
+			return RemoteResolution{}, err
+		}
+		branch, commit, err := resolveDefaultBranch(result.Output)
+		if err != nil {
+			return RemoteResolution{}, err
+		}
+		reference := "refs/heads/" + branch
+		return RemoteResolution{Reference: branch, Commit: commit, FetchReference: reference}, nil
 	case SelectorBranch:
 		branch, err := requiredSelectorValue(source.Selector)
 		if err != nil {
@@ -541,6 +552,25 @@ func (m *RemoteManager) resolve(ctx context.Context, source PackageSource, requi
 	default:
 		return RemoteResolution{}, errors.New("不支持的远程来源选择器。")
 	}
+}
+
+func resolveDefaultBranch(output string) (string, string, error) {
+	branch := ""
+	commit := ""
+	for _, line := range strings.Split(strings.TrimSpace(output), "\n") {
+		columns := strings.Fields(line)
+		if len(columns) == 3 && columns[0] == "ref:" && columns[2] == "HEAD" && strings.HasPrefix(columns[1], "refs/heads/") {
+			branch = strings.TrimPrefix(columns[1], "refs/heads/")
+			continue
+		}
+		if len(columns) == 2 && columns[1] == "HEAD" {
+			commit = strings.ToLower(columns[0])
+		}
+	}
+	if branch == "" || commit == "" {
+		return "", "", errors.New("远程仓库未提供主分支（HEAD）；请改用“指定分支”并输入分支名称。")
+	}
+	return branch, commit, nil
 }
 
 func (m *RemoteManager) resolveSingleRef(ctx context.Context, reference string, source PackageSource, git GitEnvironment) (string, error) {

--- a/backend/internal/core/remote_test.go
+++ b/backend/internal/core/remote_test.go
@@ -61,6 +61,48 @@ func TestRemoteManagerInstallsLatestSemverAndFindsUpdate(t *testing.T) {
 	}
 }
 
+func TestRemoteManagerInstallsDefaultBranchAndFindsUpdate(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	store, root := newTestStore(t)
+	repository := filepath.Join(root, "repository")
+	if err := os.MkdirAll(repository, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	runGitTest(t, repository, "init", "--quiet", "--initial-branch", "trunk")
+	runGitTest(t, repository, "config", "user.email", "tests@codex-tweaks.invalid")
+	runGitTest(t, repository, "config", "user.name", "Codex Tweaks Tests")
+	writeRemotePackage(t, repository, "1.0.0", nil)
+	commitRemotePackage(t, repository, "first")
+
+	remoteURL := "https://example.test/default-branch.git"
+	environment := environmentMap()
+	environment["GIT_CONFIG_COUNT"] = "1"
+	environment["GIT_CONFIG_KEY_0"] = "url.file://" + repository + "/.insteadOf"
+	environment["GIT_CONFIG_VALUE_0"] = remoteURL
+	environment["GIT_ALLOW_PROTOCOL"] = "file"
+	manager := NewRemoteManager(store, nil, nil, environment)
+	source := PackageSource{URL: remoteURL, Selector: NewRemoteSelector(SelectorDefaultBranch, "")}
+	installed, err := manager.Install(context.Background(), source, RemoteInstallOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if installed.Lock.ResolvedReference != "trunk" {
+		t.Fatalf("resolved reference = %q, want trunk", installed.Lock.ResolvedReference)
+	}
+
+	writeRemotePackage(t, repository, "1.0.1", nil)
+	commitRemotePackage(t, repository, "second")
+	update, err := manager.CheckForUpdate(context.Background(), installed.PackageID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if update.Status != RemoteUpdateAvailable || update.CandidateReference != "trunk" || update.CandidateCommit == update.CurrentCommit {
+		t.Fatalf("unexpected update: %#v", update)
+	}
+}
+
 func TestRemoteManagerRejectsPackageWithoutLockfile(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git unavailable")

--- a/backend/internal/core/source.go
+++ b/backend/internal/core/source.go
@@ -28,7 +28,7 @@ func ValidateSource(source PackageSource) error {
 		return errors.New("GitHub Release 选择器要求 github.com 仓库地址。")
 	}
 	switch source.Selector.Type {
-	case SelectorBranch, SelectorLatestSemverTag, SelectorTag, SelectorGitHubLatestRelease, SelectorGitHubRelease, SelectorCommit:
+	case SelectorDefaultBranch, SelectorBranch, SelectorLatestSemverTag, SelectorTag, SelectorGitHubLatestRelease, SelectorGitHubRelease, SelectorCommit:
 		return nil
 	default:
 		return errors.New("不支持的远程来源选择器。")

--- a/backend/internal/core/source_test.go
+++ b/backend/internal/core/source_test.go
@@ -15,6 +15,16 @@ func TestValidateSourceAcceptsSupportedNonCredentialedGitURLs(t *testing.T) {
 	}
 }
 
+func TestValidateSourceAcceptsDefaultBranchWithoutValue(t *testing.T) {
+	source := PackageSource{
+		URL:      "https://github.com/example/package.git",
+		Selector: NewRemoteSelector(SelectorDefaultBranch, ""),
+	}
+	if err := ValidateSource(source); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestValidateSourceRejectsCredentialsInvalidSelectorsAndNonGitHubReleases(t *testing.T) {
 	values := []PackageSource{
 		{URL: "https://user@example.com/package.git", Selector: NewRemoteSelector(SelectorBranch, "main")},

--- a/contract/presentation-contract.json
+++ b/contract/presentation-contract.json
@@ -231,6 +231,7 @@
     "selector.branchValue": "分支名称",
     "selector.commit": "指定 Commit",
     "selector.commitValue": "Commit SHA",
+    "selector.defaultBranch": "仓库主分支",
     "selector.githubLatestRelease": "GitHub 最新 Release",
     "selector.githubRelease": "指定 GitHub Release",
     "selector.githubReleaseValue": "Release 的 Tag",

--- a/windows/CodexTweaks.Windows/Generated/PresentationContract.g.cs
+++ b/windows/CodexTweaks.Windows/Generated/PresentationContract.g.cs
@@ -235,6 +235,7 @@ internal static class PresentationTextKey
     internal const string SelectorBranchValue = "selector.branchValue";
     internal const string SelectorCommit = "selector.commit";
     internal const string SelectorCommitValue = "selector.commitValue";
+    internal const string SelectorDefaultBranch = "selector.defaultBranch";
     internal const string SelectorGithubLatestRelease = "selector.githubLatestRelease";
     internal const string SelectorGithubRelease = "selector.githubRelease";
     internal const string SelectorGithubReleaseValue = "selector.githubReleaseValue";
@@ -711,6 +712,7 @@ internal static class PresentationDefaults
         [PresentationTextKey.SelectorBranchValue] = "分支名称",
         [PresentationTextKey.SelectorCommit] = "指定 Commit",
         [PresentationTextKey.SelectorCommitValue] = "Commit SHA",
+        [PresentationTextKey.SelectorDefaultBranch] = "仓库主分支",
         [PresentationTextKey.SelectorGithubLatestRelease] = "GitHub 最新 Release",
         [PresentationTextKey.SelectorGithubRelease] = "指定 GitHub Release",
         [PresentationTextKey.SelectorGithubReleaseValue] = "Release 的 Tag",

--- a/windows/CodexTweaks.Windows/MainWindow.xaml.cs
+++ b/windows/CodexTweaks.Windows/MainWindow.xaml.cs
@@ -469,6 +469,7 @@ public sealed partial class MainWindow : Window
         };
         var selectorOptions = new (string Value, string Key, bool RequiresValue)[]
         {
+            ("defaultBranch", PresentationTextKey.SelectorDefaultBranch, false),
             ("branch", PresentationTextKey.SelectorBranch, true),
             ("latestSemverTag", PresentationTextKey.SelectorLatestSemverTag, false),
             ("tag", PresentationTextKey.SelectorTag, true),
@@ -484,12 +485,14 @@ public sealed partial class MainWindow : Window
         var selectorValue = new TextBox
         {
             Header = Text(PresentationTextKey.SelectorBranchValue),
-            Text = Text(PresentationTextKey.SelectorBranchDefault),
+            IsEnabled = false,
+            Visibility = Visibility.Collapsed,
         };
         selector.SelectionChanged += (_, _) =>
         {
             var selected = selectorOptions[selector.SelectedIndex];
             selectorValue.IsEnabled = selected.RequiresValue;
+            selectorValue.Visibility = selected.RequiresValue ? Visibility.Visible : Visibility.Collapsed;
             selectorValue.Header = selected.Value switch
             {
                 "tag" => Text(PresentationTextKey.SelectorTagValue),
@@ -497,10 +500,9 @@ public sealed partial class MainWindow : Window
                 "commit" => Text(PresentationTextKey.SelectorCommitValue),
                 _ => Text(PresentationTextKey.SelectorBranchValue),
             };
-            if (!selected.RequiresValue)
-            {
-                selectorValue.Text = string.Empty;
-            }
+            selectorValue.Text = selected.Value == "branch"
+                ? Text(PresentationTextKey.SelectorBranchDefault)
+                : string.Empty;
         };
         var content = new StackPanel { Spacing = Tokens.ControlSpacing };
         content.Children.Add(repository);


### PR DESCRIPTION
## 变更内容

- 新增 defaultBranch 远程选择器，通过 git ls-remote --symref 动态解析仓库远端 HEAD，并锁定主分支 commit
- macOS SwiftUI 与 Windows WinUI 安装对话框新增“仓库主分支”，并设为默认选择
- 同步 Go Presentation Contract、双端生成绑定、包开发 Skill 文档与回归测试
- 使用只有 trunk、没有 main 的测试仓库覆盖安装与后续更新解析

## 验证

- mise run verify：通过（actionlint、ShellCheck、Go vet/race、Windows amd64/arm64 Go 构建、Contract 漂移、Swift 测试与 macOS Release build）
- git diff --cached --check：通过
- Windows 11 ARM64 Parallels VM：contract check、go vet、go test ./... 通过
- Windows VM scripts/build-windows.ps1：win-x64 / win-arm64 通过
- Windows VM scripts/package-windows.ps1 -Channel stable：两架构 installer/full package/feed 通过（本地 unsigned 模式）
- Windows VM scripts/verify-windows.ps1 -RequirePackages：两架构 PE/PRI/XAML/资源/包结构及精确 6 个 staging 资产通过；ARM64 原生 RPC smoke 通过，x64 原生执行由 PR CI 的 x64 runner 覆盖