### PR TITLE
fix(macOS): 关闭主窗口后保持后台运行

### DIFF
--- a/app/Sources/CodexTweaksApp.swift
+++ b/app/Sources/CodexTweaksApp.swift
@@ -25,7 +25,11 @@ struct CodexTweaksApp: App {
         )
 
         MenuBarExtra(isInserted: $isMenuBarExtraInserted) {
-            MenuBarContent(model: model, updateChecker: updateChecker)
+            MenuBarContent(
+                appDelegate: appDelegate,
+                model: model,
+                updateChecker: updateChecker
+            )
                 .environment(\.locale, model.displayLocale)
         } label: {
             Image(systemName: model.menuBarSymbol)
@@ -35,11 +39,22 @@ struct CodexTweaksApp: App {
     }
 }
 
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
+    // Keep the Scene-managed window alive when the close button hides it.
+    private var mainWindow: NSWindow?
+
     func applicationWillFinishLaunching(_ notification: Notification) {
         if ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil {
             NSApplication.shared.setActivationPolicy(.prohibited)
+            return
         }
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(mainWindowDidBecomeKey(_:)),
+            name: NSWindow.didBecomeKeyNotification,
+            object: nil
+        )
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -56,8 +71,53 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         guard ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil else {
             return
         }
+        NotificationCenter.default.removeObserver(self)
         Task { @MainActor in
             AppModel.shared.stop()
         }
+    }
+
+    func showMainWindow() -> Bool {
+        guard let mainWindow else { return false }
+        NSApplication.shared.activate(ignoringOtherApps: true)
+        if mainWindow.isMiniaturized {
+            mainWindow.deminiaturize(nil)
+        }
+        mainWindow.makeKeyAndOrderFront(nil)
+        return true
+    }
+
+    // Closing the main window hides it while the menu bar and backend stay alive.
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        sender.orderOut(nil)
+        return false
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        false
+    }
+
+    func applicationShouldHandleReopen(
+        _ sender: NSApplication,
+        hasVisibleWindows visibleWindows: Bool
+    ) -> Bool {
+        guard !visibleWindows else { return true }
+        return !showMainWindow()
+    }
+
+    @objc
+    private func mainWindowDidBecomeKey(_ notification: Notification) {
+        guard let window = notification.object as? NSWindow,
+              !(window is NSPanel),
+              !window.isSheet,
+              window.parent == nil,
+              window.styleMask.contains(.titled),
+              mainWindow == nil || mainWindow === window else {
+            return
+        }
+        mainWindow = window
+        window.isReleasedWhenClosed = false
+        window.isRestorable = false
+        window.delegate = self
     }
 }

--- a/app/Sources/MenuBarContent.swift
+++ b/app/Sources/MenuBarContent.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct MenuBarContent: View {
     @Environment(\.openWindow) private var openWindow
+    let appDelegate: AppDelegate
     @ObservedObject var model: AppModel
     @ObservedObject var updateChecker: UpdateChecker
 
@@ -17,8 +18,10 @@ struct MenuBarContent: View {
         Divider()
 
         Button(model.text(.menuShow)) {
-            NSApplication.shared.activate(ignoringOtherApps: true)
-            openWindow(id: "main")
+            if !appDelegate.showMainWindow() {
+                NSApplication.shared.activate(ignoringOtherApps: true)
+                openWindow(id: "main")
+            }
         }
         .keyboardShortcut("1")
 

--- a/app/Tests/TestIsolationTests.swift
+++ b/app/Tests/TestIsolationTests.swift
@@ -25,6 +25,26 @@ final class TestIsolationTests: XCTestCase {
         XCTAssertTrue(packageSource.contains("VStack(alignment: .leading, spacing: 0)"))
     }
 
+    func testMainWindowCloseKeepsTheApplicationRunning() throws {
+        let source = try source(named: "CodexTweaksApp.swift")
+        let closeStart = try XCTUnwrap(
+            source.range(of: "func windowShouldClose(_ sender: NSWindow) -> Bool")
+        )
+        let terminateStart = try XCTUnwrap(
+            source.range(of: "func applicationShouldTerminateAfterLastWindowClosed")
+        )
+        let reopenStart = try XCTUnwrap(
+            source.range(of: "func applicationShouldHandleReopen")
+        )
+        let closeSource = source[closeStart.lowerBound..<terminateStart.lowerBound]
+        let terminateSource = source[terminateStart.lowerBound..<reopenStart.lowerBound]
+
+        XCTAssertTrue(source.contains("NSWindowDelegate"))
+        XCTAssertTrue(closeSource.contains("sender.orderOut(nil)"))
+        XCTAssertTrue(closeSource.contains("return false"))
+        XCTAssertTrue(terminateSource.contains("false"))
+    }
+
     private func source(named name: String) throws -> String {
         let sourceURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()


### PR DESCRIPTION
## 变更内容

- 将主窗口红色关闭按钮行为改为隐藏窗口，保留菜单栏与 Go sidecar 运行。
- 由 `AppDelegate` 持有并复用同一个主窗口；Dock 重新打开与菜单栏“显示”恢复该窗口，避免重复创建。
- 保留显式退出的原有终止语义，并添加源码级生命周期回归测试。

## 验证

- `mise run verify`：通过（根任务在交付前完成，覆盖 actionlint、ShellCheck、Go vet/race、Windows Go amd64/arm64 交叉构建、contract、Swift tests、macOS Release build、generated drift）。
- `mise run test`：通过（本分支交付前复跑）。
- 真实 Debug bundle 生命周期验证：关闭主窗口后 app 与 sidecar PID 均存活；Dock reopen 复用同一实例且不重复窗口；显式退出后两者均停止。
- `git diff --check` / `git diff --cached --check`：通过。

## 边界

- 未替换或安装 `/Applications/Codex Tweaks.app`。
- 未修改 Windows 或 DJOneHubNative。