### PR TITLE
fix(windows): 修复 Node 带空格路径执行

### DIFF
--- a/backend/internal/core/builder.go
+++ b/backend/internal/core/builder.go
@@ -73,7 +73,8 @@ func (b *Builder) Build(ctx context.Context, pkg Package, installDependencies, a
 		if !isRegularNonSymlink(filepath.Join(pkg.Directory, "package-lock.json")) {
 			return PackageBuildRecord{}, errors.New("包含 npm 依赖的包必须提供 package-lock.json。")
 		}
-		result, err := b.runner.Run(ctx, node.NPMPath, DependencyInstallArguments, pkg.Directory, environment)
+		executable, arguments := node.npmInvocation(DependencyInstallArguments)
+		result, err := b.runner.Run(ctx, executable, arguments, pkg.Directory, environment)
 		if err != nil {
 			return PackageBuildRecord{}, err
 		}
@@ -93,7 +94,8 @@ func (b *Builder) Build(ctx context.Context, pkg Package, installDependencies, a
 	defer os.RemoveAll(stagingDirectory)
 	entryPath := filepath.Join(pkg.Directory, filepath.FromSlash(pkg.Manifest.CodexTweaks.Entrypoints.Renderer))
 	javaScriptPath := filepath.Join(stagingDirectory, "bundle.js")
-	result, err := b.runner.Run(ctx, node.NPXPath, EsbuildArguments(entryPath, javaScriptPath, allowCompilerDownload), pkg.Directory, environment)
+	executable, arguments := node.npxInvocation(EsbuildArguments(entryPath, javaScriptPath, allowCompilerDownload))
+	result, err := b.runner.Run(ctx, executable, arguments, pkg.Directory, environment)
 	if err != nil {
 		return PackageBuildRecord{}, err
 	}
@@ -122,7 +124,8 @@ func (b *Builder) Build(ctx context.Context, pkg Package, installDependencies, a
 	if hasNode {
 		nodeEntryPath := filepath.Join(pkg.Directory, filepath.FromSlash(*pkg.Manifest.CodexTweaks.Entrypoints.Node))
 		nodeJavaScriptPath := filepath.Join(stagingDirectory, "node-bundle.cjs")
-		result, err := b.runner.Run(ctx, node.NPXPath, EsbuildNodeArguments(nodeEntryPath, nodeJavaScriptPath, allowCompilerDownload), pkg.Directory, environment)
+		executable, arguments := node.npxInvocation(EsbuildNodeArguments(nodeEntryPath, nodeJavaScriptPath, allowCompilerDownload))
+		result, err := b.runner.Run(ctx, executable, arguments, pkg.Directory, environment)
 		if err != nil {
 			return PackageBuildRecord{}, err
 		}
@@ -235,12 +238,50 @@ func installedNodeCandidates(root, executable, binDirectory string) []string {
 func nodeCompanionPaths(binDirectory string) (string, string, bool) {
 	npmNames, npxNames := []string{"npm"}, []string{"npx"}
 	if runtime.GOOS == "windows" {
-		npmNames = []string{"npm.cmd", "npm.exe"}
-		npxNames = []string{"npx.cmd", "npx.exe"}
+		// Native shims preserve argv without cmd.exe's separate and unsafe
+		// quoting rules, so prefer them whenever a version manager provides one.
+		npmNames = []string{"npm.exe", "npm.cmd"}
+		npxNames = []string{"npx.exe", "npx.cmd"}
 	}
 	npmPath := firstExecutablePath(binDirectory, npmNames)
 	npxPath := firstExecutablePath(binDirectory, npxNames)
-	return npmPath, npxPath, npmPath != "" && npxPath != ""
+	if npmPath == "" || npxPath == "" {
+		return "", "", false
+	}
+	if runtime.GOOS == "windows" {
+		for _, companion := range []struct {
+			launcher string
+			cliName  string
+		}{{npmPath, "npm-cli.js"}, {npxPath, "npx-cli.js"}} {
+			if strings.EqualFold(filepath.Ext(companion.launcher), ".cmd") && !isRegularNonSymlink(nodePackageManagerCLIPath(companion.launcher, companion.cliName)) {
+				return "", "", false
+			}
+		}
+	}
+	return npmPath, npxPath, true
+}
+
+func (environment NodeEnvironment) npmInvocation(arguments []string) (string, []string) {
+	return environment.packageManagerInvocation(environment.NPMPath, "npm-cli.js", arguments)
+}
+
+func (environment NodeEnvironment) npxInvocation(arguments []string) (string, []string) {
+	return environment.packageManagerInvocation(environment.NPXPath, "npx-cli.js", arguments)
+}
+
+func (environment NodeEnvironment) packageManagerInvocation(launcher, cliName string, arguments []string) (string, []string) {
+	if runtime.GOOS == "windows" && strings.EqualFold(filepath.Ext(launcher), ".cmd") {
+		// npm.cmd/npx.cmd are wrappers around these JavaScript entry points.
+		// Run them through node.exe directly so Program Files and package paths
+		// containing spaces never pass through cmd.exe's incompatible parser.
+		cliPath := nodePackageManagerCLIPath(launcher, cliName)
+		return environment.NodePath, append([]string{cliPath}, arguments...)
+	}
+	return launcher, arguments
+}
+
+func nodePackageManagerCLIPath(launcher, cliName string) string {
+	return filepath.Join(filepath.Dir(launcher), "node_modules", "npm", "bin", cliName)
 }
 
 func firstExecutablePath(directory string, names []string) string {

--- a/backend/internal/core/environment_windows_test.go
+++ b/backend/internal/core/environment_windows_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -79,6 +80,9 @@ func TestWindowsNodeDetectionAcceptsCommandAndExecutableCompanions(t *testing.T)
 					t.Fatal(err)
 				}
 			}
+			if extension == ".cmd" {
+				writeWindowsNodeCLIEntrypoints(t, binDirectory)
+			}
 			t.Setenv("PATH", binDirectory)
 
 			runner := nodeDetectionRunnerFunc(func(_ context.Context, executable string, arguments []string, directory string, _ []string) (CommandResult, error) {
@@ -95,6 +99,78 @@ func TestWindowsNodeDetectionAcceptsCommandAndExecutableCompanions(t *testing.T)
 				t.Fatalf("unexpected Node environment: %#v", environment)
 			}
 		})
+	}
+}
+
+func TestWindowsNodeDetectionPrefersNativeCompanions(t *testing.T) {
+	binDirectory := t.TempDir()
+	for _, name := range []string{"npm.cmd", "npm.exe", "npx.cmd", "npx.exe"} {
+		if err := os.WriteFile(filepath.Join(binDirectory, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	npmPath, npxPath, ok := nodeCompanionPaths(binDirectory)
+	if !ok || npmPath != filepath.Join(binDirectory, "npm.exe") || npxPath != filepath.Join(binDirectory, "npx.exe") {
+		t.Fatalf("native package manager shims were not preferred: npm=%q npx=%q ok=%v", npmPath, npxPath, ok)
+	}
+}
+
+func TestWindowsNodeDetectionRejectsCommandShimsWithoutCLIEntrypoints(t *testing.T) {
+	binDirectory := t.TempDir()
+	for _, name := range []string{"npm.cmd", "npx.cmd"} {
+		if err := os.WriteFile(filepath.Join(binDirectory, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if npmPath, npxPath, ok := nodeCompanionPaths(binDirectory); ok || npmPath != "" || npxPath != "" {
+		t.Fatalf("command shims without trusted CLI entrypoints were accepted: npm=%q npx=%q", npmPath, npxPath)
+	}
+}
+
+func TestWindowsNodePackageManagerInvocationsBypassCommandShell(t *testing.T) {
+	binDirectory := filepath.Join(t.TempDir(), "Program Files", "nodejs")
+	if err := os.MkdirAll(binDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeWindowsNodeCLIEntrypoints(t, binDirectory)
+	environment := NodeEnvironment{
+		NodePath: filepath.Join(binDirectory, "node.exe"),
+		NPMPath:  filepath.Join(binDirectory, "npm.cmd"),
+		NPXPath:  filepath.Join(binDirectory, "npx.cmd"),
+	}
+	tests := []struct {
+		name       string
+		invocation func([]string) (string, []string)
+		cliName    string
+		arguments  []string
+	}{
+		{name: "npm", invocation: environment.npmInvocation, cliName: "npm-cli.js", arguments: []string{"ci", "--ignore-scripts"}},
+		{name: "npx", invocation: environment.npxInvocation, cliName: "npx-cli.js", arguments: []string{"--yes", `C:\\Package Source\\index.ts`, `--define:process.env.NODE_ENV="production"`, `--outfile=C:\\Build Output\\bundle.js`}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			executable, arguments := test.invocation(test.arguments)
+			if executable != environment.NodePath {
+				t.Fatalf("invocation executable = %q, want node executable %q", executable, environment.NodePath)
+			}
+			expectedArguments := append([]string{nodePackageManagerCLIPath(filepath.Join(binDirectory, test.name+".cmd"), test.cliName)}, test.arguments...)
+			if !reflect.DeepEqual(arguments, expectedArguments) {
+				t.Fatalf("invocation arguments = %#v, want %#v", arguments, expectedArguments)
+			}
+		})
+	}
+}
+
+func writeWindowsNodeCLIEntrypoints(t *testing.T, binDirectory string) {
+	t.Helper()
+	cliDirectory := filepath.Join(binDirectory, "node_modules", "npm", "bin")
+	if err := os.MkdirAll(cliDirectory, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"npm-cli.js", "npx-cli.js"} {
+		if err := os.WriteFile(filepath.Join(cliDirectory, name), []byte("fixture"), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
 }
 

--- a/backend/internal/core/node_runtime.go
+++ b/backend/internal/core/node_runtime.go
@@ -263,7 +263,8 @@ func (s *NodeRuntimeSupervisor) runAuthorizedInstallScripts(
 		return err
 	}
 	environmentValues := processEnvironment(filepath.Dir(environment.NodePath), environmentMap())
-	result, err := s.runner.Run(ctx, environment.NPMPath, DependencyInstallWithScriptsArguments, pkg.Directory, environmentValues)
+	executable, arguments := environment.npmInvocation(DependencyInstallWithScriptsArguments)
+	result, err := s.runner.Run(ctx, executable, arguments, pkg.Directory, environmentValues)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## 变更内容

- Windows 优先使用原生 `npm.exe` / `npx.exe` companion，避免不必要地经过命令解释器。
- 仅有 `.cmd` shim 时，改为通过 `node.exe` 直接执行 `npm-cli.js` / `npx-cli.js`，确保 `Program Files` 与功能包路径中的空格按原始 argv 保留。
- 统一依赖安装、renderer/node bundle 编译与授权后 install scripts 的安全调用路径，并补充 Windows 回归测试。

## 验证

- `git diff --check`：通过。
- `mise run verify`：通过；覆盖 workflow lint、Go vet/race/tests、Windows amd64/arm64 cross-build、Presentation Contract、Swift tests、macOS Release build 与生成文件漂移检查。
- Windows 11 ARM64 原生 core test binary：通过。
- Windows 11 ARM64 + Node v24.13.0（Node 位于带空格目录）运行 `TestBuilderBuildsBundledSampleOnDesktop`：真实 npx/esbuild 编译通过。
- Windows 原生顺序门禁：`scripts/build-windows.ps1 -Version 3.5.2 -BuildNumber 1`、`scripts/package-windows.ps1 -Version 3.5.2 -Channel stable`、`scripts/verify-windows.ps1 -Version 3.5.2 -Channel stable -RequirePackages` 全部通过，覆盖 x64 与 ARM64。