### PR TITLE
fix: 注入前等待 Codex 页面 DOM 就绪

### DIFF
--- a/backend/internal/core/cdp.go
+++ b/backend/internal/core/cdp.go
@@ -20,6 +20,10 @@ var (
 	ErrNoCodexUITargets       = errors.New("没有发现可重启的 Codex 界面")
 )
 
+const targetDOMReadyProbeScript = `(() => ({
+  ready: Boolean(document.documentElement && document.head && document.body)
+}))()`
+
 type CDPTarget struct {
 	ID                   string  `json:"id"`
 	Type                 string  `json:"type"`
@@ -96,8 +100,17 @@ func (s *CDPService) Inject(ctx context.Context, payload Payload, forceGeneratio
 		return CDPInjectionResult{}, err
 	}
 	s.reconcileRendererSessionsLocked(targets)
-	result := CDPInjectionResult{TargetCount: len(targets), PackageErrors: map[string]string{}}
+	result := CDPInjectionResult{PackageErrors: map[string]string{}}
 	for _, target := range targets {
+		ready, err := s.targetDOMReady(ctx, *target.WebSocketDebuggerURL)
+		if err != nil {
+			s.logError(fmt.Sprintf("目标 %s 页面就绪检查失败：%v", target.ID, err))
+			continue
+		}
+		if !ready {
+			continue
+		}
+		result.TargetCount++
 		bridgeSessionID, nodeTokens, settingsAdapter, err := s.rendererBridgeForTargetLocked(ctx, target, payload)
 		if err != nil {
 			s.logError(fmt.Sprintf("目标 %s 无法建立能力通道：%v", target.ID, err))
@@ -122,6 +135,15 @@ func (s *CDPService) Inject(ctx context.Context, payload Payload, forceGeneratio
 		mergeInjectionPackageErrors(result.PackageErrors, value)
 	}
 	return result, nil
+}
+
+func (s *CDPService) targetDOMReady(ctx context.Context, debuggerURL string) (bool, error) {
+	value, err := s.evaluate(ctx, targetDOMReadyProbeScript, debuggerURL)
+	if err != nil {
+		return false, err
+	}
+	ready, _ := value["ready"].(bool)
+	return ready, nil
 }
 
 func mergeInjectionPackageErrors(destination map[string]string, value map[string]any) {

--- a/backend/internal/core/cdp_test.go
+++ b/backend/internal/core/cdp_test.go
@@ -57,6 +57,14 @@ func TestInjectUsesSmallProbeAfterInitialRuntimeSetup(t *testing.T) {
 			expression, _ := params["expression"].(string)
 			mutex.Lock()
 			expressions = append(expressions, expression)
+			if expression == targetDOMReadyProbeScript {
+				mutex.Unlock()
+				_ = connection.WriteJSON(map[string]any{
+					"id":     command["id"],
+					"result": map[string]any{"result": map[string]any{"value": map[string]any{"ready": true}}},
+				})
+				return
+			}
 			isFullInjection := strings.Contains(expression, packageMarker)
 			status := "stale"
 			if isFullInjection {
@@ -97,14 +105,80 @@ func TestInjectUsesSmallProbeAfterInitialRuntimeSetup(t *testing.T) {
 
 	mutex.Lock()
 	defer mutex.Unlock()
-	if len(expressions) != 3 {
-		t.Fatalf("CDP evaluate count = %d, want probe + initial injection + probe", len(expressions))
+	if len(expressions) != 5 {
+		t.Fatalf("CDP evaluate count = %d, want readiness + probe + initial injection + readiness + probe", len(expressions))
 	}
-	if strings.Contains(expressions[0], packageMarker) || !strings.Contains(expressions[1], packageMarker) || strings.Contains(expressions[2], packageMarker) {
+	if expressions[0] != targetDOMReadyProbeScript || strings.Contains(expressions[1], packageMarker) || !strings.Contains(expressions[2], packageMarker) || expressions[3] != targetDOMReadyProbeScript || strings.Contains(expressions[4], packageMarker) {
 		t.Fatalf("unexpected probe/full injection sequence: %#v", expressions)
 	}
-	if len(expressions[2]) >= len(expressions[1])/4 {
-		t.Fatalf("unchanged runtime probe is not lightweight: probe=%d full=%d", len(expressions[2]), len(expressions[1]))
+	if len(expressions[4]) >= len(expressions[2])/4 {
+		t.Fatalf("unchanged runtime probe is not lightweight: probe=%d full=%d", len(expressions[4]), len(expressions[2]))
+	}
+}
+
+func TestInjectWaitsForDOMReady(t *testing.T) {
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	ready := false
+	fullInjectionCount := 0
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/json/list":
+			debuggerURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/devtools/page/codex-main"
+			_ = json.NewEncoder(writer).Encode([]CDPTarget{{
+				ID: "codex-main", Type: "page", URL: "app://-/index.html", WebSocketDebuggerURL: &debuggerURL,
+			}})
+		case "/devtools/page/codex-main":
+			connection, err := upgrader.Upgrade(writer, request, nil)
+			if err != nil {
+				return
+			}
+			defer connection.Close()
+			command := map[string]any{}
+			if connection.ReadJSON(&command) != nil {
+				return
+			}
+			params, _ := command["params"].(map[string]any)
+			expression, _ := params["expression"].(string)
+			value := map[string]any{"status": "stale", "packageErrors": []any{}}
+			if expression == targetDOMReadyProbeScript {
+				value = map[string]any{"ready": ready}
+			} else if strings.Contains(expression, "slow-start-package") {
+				fullInjectionCount++
+				value = map[string]any{"status": "injected", "packageErrors": []any{}}
+			}
+			_ = connection.WriteJSON(map[string]any{
+				"id": command["id"], "result": map[string]any{"result": map[string]any{"value": value}},
+			})
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	service := NewCDPService(nil)
+	service.Endpoint = server.URL + "/json/list"
+	service.AllowedOrigin = server.URL
+	payload := Payload{Version: "stable", Packages: []CompiledPackage{{
+		ID: "sample", Name: "sample", Version: "1.0.0",
+		JavaScript: "module.exports.activate = () => {}; /* slow-start-package */",
+	}}}
+
+	result, err := service.Inject(context.Background(), payload, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TargetCount != 0 || result.SuccessCount != 0 || fullInjectionCount != 0 {
+		t.Fatalf("unready target was injected: result=%#v full=%d", result, fullInjectionCount)
+	}
+
+	ready = true
+	result, err = service.Inject(context.Background(), payload, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.TargetCount != 1 || result.SuccessCount != 1 || fullInjectionCount != 1 {
+		t.Fatalf("ready target was not injected: result=%#v full=%d", result, fullInjectionCount)
 	}
 }
 


### PR DESCRIPTION
## 问题

Codex 冷启动较慢的机器上（我这台 Windows 11 大概 3~5 秒），Codex Tweaks 会出现「功能包显示已加载，但完全不生效」的状态：挂件固定在角落、无法拖动、hover 动画消失，设置面板里的注入项也没了反应。重启 Codex 之后才恢复，下次冷启动又可能复现。

## 根因

`CDPService.Inject` 只要 `/json/list` 返回了 page 目标就立刻注入，没有确认这个页面的 DOM 是否已经建立。Codex 启动早期 `document.head` / `document.body` 还是 `null`，于是注入脚本走进兜底分支：

- `injection.go`：`(document.body || document.documentElement).appendChild(host)` → `#codex-tweaks-root` 被挂到 `<html>` 上
- `packageSetupScript`：`(document.head || document.documentElement).appendChild(style)` → 功能包样式同样挂错位置
- 设置面板适配器里的 `observer.observe(document.documentElement, …)` 在 `documentElement` 缺失时会直接抛错

真正让它「粘住」的是缓存：这次半成功的注入已经写入了 `__CODEX_TWEAKS__`，之后每 2 秒一次的 `injectionRuntimeProbeScript` 只要看到 `runtime.version` 匹配且 `#codex-tweaks-root` 仍在文档里，就返回 `unchanged`。于是控制器认为一切正常，永远不会重新注入，直到用户手动重启 Codex。

## 修复

注入每个目标之前先跑一个极小的就绪探针：

```js
(() => ({ ready: Boolean(document.documentElement && document.head && document.body) }))()
```

未就绪的目标直接跳过，并且**不计入** `TargetCount`。`Controller.Refresh` 已有的 2 秒轮询会在下一轮重试，期间状态停在 `StatusWaitingForPage`（等待页面），DOM 就绪后再执行完整注入。

设计上的两点说明：

- 之前 `TargetCount = len(targets)`，未就绪的页面会被算成「发现页面但注入没有成功」的错误态；现在改成只统计真正尝试注入的目标，语义上「页面还没准备好」应该是等待而不是报错。
- 就绪探针本身非常小；它会在每轮注入检查前执行一次，因此会增加一次轻量 `Runtime.evaluate`，但不会触发额外的完整注入或功能包执行。

## 验证

在 Windows 11 + Go 1.26.4 上：

- `go run ./cmd/contractgen -root .. -check` 通过（无生成物漂移）
- `go vet ./...` 通过
- `go test ./...` 全部通过
- 新增 `TestInjectWaitsForDOMReady`：未就绪时 `TargetCount/SuccessCount/完整注入次数` 全为 0；置为就绪后各为 1。把 `cdp.go` 里的跳过分支临时短路掉，该测试会红（`unready target was injected: TargetCount:1 SuccessCount:1 full=1`），确认不是空测试
- `TestInjectUsesSmallProbeAfterInitialRuntimeSetup` 的 evaluate 序列断言同步更新为「就绪探针 + 轻量 probe + 完整注入 + 就绪探针 + 轻量 probe」
- 本机实际跑了打了这个补丁的 sidecar：冷启动时状态先停在「等待页面」，Codex 界面出来后自动完成注入，挂件恢复正常拖动和 hover 动画

## 范围

只改了 `backend/internal/core/cdp.go` 和对应测试，与平台无关（macOS 同样受益，只是启动更快不容易触发）。我本地另外还试过给 Windows 启动参数加 `--disable-gpu`，那个更像是我这台机器的个例，也可能影响别的用户，所以没有放进这个 PR。
